### PR TITLE
Code reviews are counted only if they occur after the most recent push.

### DIFF
--- a/.thumbs.yml
+++ b/.thumbs.yml
@@ -2,6 +2,6 @@ minimum_reviewers: 2
 merge: true
 build_steps:
  - env
- - bundle exec rake test TESTOPTS=-v
+ - bundle exec ruby test/test.rb
 org_mode: true
 timeout: 1799

--- a/lib/thumbs.rb
+++ b/lib/thumbs.rb
@@ -17,10 +17,9 @@ require 'thumbs/pull_request_worker'
 module Thumbs
   def self.start_logger
     logger  = Log4r::Logger.new 'Thumbs'
-    logger.outputters << Log4r::Outputter.stderr
-    file = Log4r::FileOutputter.new('app-file', :filename => 'log/thumbs.log')
-    file.formatter = Log4r::PatternFormatter.new(:pattern => "[%l] %d :: %m")
-    logger.outputters << file
+    outputter = Log4r::Outputter.stdout
+    outputter.formatter = Log4r::PatternFormatter.new(:pattern => "[%l] %d :: %m")
+    logger.outputters << outputter
   end
 end
 

--- a/test/test_build_steps.rb
+++ b/test/test_build_steps.rb
@@ -1,4 +1,3 @@
-
 unit_tests do
 
   test "can try pr merge" do
@@ -101,7 +100,7 @@ unit_tests do
 
 
   test "pr should not be merged" do
-    cassette(:load_pr) do
+    default_vcr_state do
       prw=Thumbs::PullRequestWorker.new(:repo => TESTREPO, :pr => TESTPR)
       assert prw.minimum_reviewers==2
       assert prw.respond_to?(:reviews)
@@ -115,23 +114,16 @@ unit_tests do
   end
 
   test "can verify valid for merge" do
-    cassette(:load_pr) do
-      cassette(:load_comments) do
-        cassette(:issue_comments, :record => :new_episodes) do
-          prw=Thumbs::PullRequestWorker.new(:repo => TESTREPO, :pr => TESTPR)
-          prw.build_steps=["make test"]
-          cassette(:validate_comments) do
-            prw.try_merge
-            prw.run_build_steps
-            cassette(:get_state) do
-              assert_equal false, prw.valid_for_merge?
-            end
-          end
-        end
+    default_vcr_state do
+      prw=Thumbs::PullRequestWorker.new(:repo => TESTREPO, :pr => TESTPR)
+      prw.build_steps=["make test"]
+      prw.try_merge
+      prw.run_build_steps
+      cassette(:get_state) do
+        assert_equal false, prw.valid_for_merge?
       end
     end
   end
-
 
   test "unmergable with failing build steps" do
     cassette(:load_pr) do
@@ -177,12 +169,14 @@ unit_tests do
     cassette(:load_pr) do
       prw=Thumbs::PullRequestWorker.new(:repo => TESTREPO, :pr => TESTPR)
       cassette(:get_comments) do
-        comment_length = prw.comments.length
-        cassette(:add_comment_test) do
-          assert prw.respond_to?(:add_comment)
-          comment = prw.add_comment("test")
-          assert comment.to_h.key?(:created_at), comment.to_h.to_yaml
-          assert comment.to_h.key?(:id), comment.to_h.to_yaml
+        cassette(:get_events) do
+          comment_length = prw.comments.length
+          cassette(:add_comment_test) do
+            assert prw.respond_to?(:add_comment)
+            comment = prw.add_comment("test")
+            assert comment.to_h.key?(:created_at), comment.to_h.to_yaml
+            assert comment.to_h.key?(:id), comment.to_h.to_yaml
+          end
         end
       end
     end
@@ -219,85 +213,43 @@ unit_tests do
   end
 
   test "code reviews from random users are not counted" do
-
     cassette(:load_pr) do
       cassette(:load_comments) do
         prw=Thumbs::PullRequestWorker.new(:repo => ORGTESTREPO, :pr => ORGTESTPR)
         cassette(:load_comments_update, :record => :all) do
           cassette(:get_state, :record => :new_episodes) do
             assert_equal false, prw.valid_for_merge?
-
             cassette(:update_reviews, :record => :all) do
               assert prw.review_count => 2
               prw.run_build_steps
               assert_equal false, prw.valid_for_merge?, prw.build_status
             end
-
           end
-
-
         end
       end
-
     end
   end
 
-  # test "ensure code reviews are from org members" do
-  #   cassette(:load_pull_request, :record => :new_episodes) do
-  #     cassette(:load_comments, :record => :new_episodes) do
-  #       prw=Thumbs::PullRequestWorker.new(:repo => ORGTESTREPO, :pr => ORGTESTPR)
-  #
-  #       remove_comments(ORGTESTREPO, ORGTESTPR)
-  #       assert prw.review_count == 0
-  #       cassette(:get_state) do
-  #
-  #         assert_equal false, prw.valid_for_merge?
-  #
-  #         cassette(:issue_comments_update) do
-  #
-  #
-  #           assert prw.review_count == 0
-  #           create_org_member_test_code_reviews(ORGTESTREPO, ORGTESTPR)
-  #           assert prw.review_count == 2, prw.review_count.to_s
-  #           assert prw.review_count >= prw.minimum_reviewers
-  #           assert prw.aggregate_build_status_result == :ok
-  #
-  #           prw.try_merge
-  #           prw.run_build_steps
-  #           cassette(:get_state_updated_false) do
-  #             assert_equal false, prw.valid_for_merge?
-  #             cassette(:get_state_updated_true) do
-  #               prw.thumb_config['merge']=true
-  #               assert_equal true, prw.valid_for_merge?
-  #             end
-  #           end
-  #         end
-  #       end
-  #     end
-  #   end
-  # end
-
-
   test "should not merge if merge false in thumbs." do
-    cassette(:load_pr) do
-      cassette(:load_comments) do
-        prw=Thumbs::PullRequestWorker.new(:repo => TESTREPO, :pr => TESTPR)
-        prw.try_merge
-        assert prw.thumb_config.key?('merge')
-        assert prw.thumb_config['merge'] == false
-
-        cassette(:get_state) do
-          assert_equal false, prw.valid_for_merge?
+    default_vcr_state do
+      prw=Thumbs::PullRequestWorker.new(:repo => TESTREPO, :pr => TESTPR)
+      prw.try_merge
+      assert prw.thumb_config.key?('merge')
+      assert prw.thumb_config['merge'] == false
+      cassette(:get_state, :record => :all) do
+        assert_equal false, prw.valid_for_merge?
+        cassette(:create_code_reviews, :record => :all) do
           create_test_code_reviews(TESTREPO, TESTPR)
-          cassette(:get_post_code_review_count) do
-            assert prw.review_count >= 2, prw.review_count.to_s
+            assert prw.review_count >= 1, prw.review_count.to_s
+          cassette(:get_post_code_review_count, :record => :all) do
+
             assert prw.aggregate_build_status_result == :ok
-            cassette(:get_updated_state) do
+            cassette(:get_updated_state, :record => :all) do
               assert_equal false, prw.valid_for_merge?
+              cassette(:get_valid_for_merge, :record => :all) do
               prw.thumb_config['merge'] = true
-
               assert_equal true, prw.valid_for_merge?
-
+              end
             end
           end
         end
@@ -307,8 +259,6 @@ unit_tests do
 
   test "should identify org code reviews" do
     cassette(:remove_org_comments, :record => :all) do
-      remove_comments(ORGTESTREPO, ORGTESTPR)
-
       cassette(:load_org_pr) do
         cassette(:load_org_comments_issues) do
           prw=Thumbs::PullRequestWorker.new(:repo => ORGTESTREPO, :pr => ORGTESTPR)
@@ -318,14 +268,33 @@ unit_tests do
             assert prw.respond_to?(:org_member_code_reviews), "doesnt respond to"
             create_org_member_test_code_reviews(ORGTESTREPO, ORGTESTPR)
             cassette(:post_add_code_review_update, :record => :all) do
-
               assert prw.org_member_code_reviews.length > org_member_code_review_count, org_member_code_review_count.to_s
-              remove_comments(ORGTESTREPO, ORGTESTPR)
             end
           end
         end
       end
+    end
+  end
 
+  test "can get events for pr" do
+    default_vcr_state do
+      prw=Thumbs::PullRequestWorker.new(:repo => TESTREPO, :pr => TESTPR)
+      assert prw.respond_to?(:events)
+      events = prw.events
+      assert events.kind_of?(Array)
+      assert events.first.kind_of?(Hash)
+      assert events.first.key?(:created_at)
+    end
+  end
+
+  test "can get comments after sha" do
+    default_vcr_state do
+      prw=Thumbs::PullRequestWorker.new(:repo => TESTREPO, :pr => TESTPR)
+      comments = prw.comments
+      sha_time_stamp=prw.push_time_stamp(prw.pr.head.sha)
+      comments_after_sha=prw.client.issue_comments(prw.repo, prw.pr.number).collect { |c| c.to_h if c[:created_at] > sha_time_stamp }.compact
+      assert_equal comments_after_sha, comments
     end
   end
 end
+

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -15,10 +15,10 @@ TESTPR=453
 ORGTESTREPO='basho-bin/tester'
 ORGTEST_PRW=Thumbs::PullRequestWorker.new(:repo => TESTREPO, :pr => 27)
 ORGTESTPR=27
-#Thumbs.start_logger if ENV.key?('DEBUG')
+Thumbs.start_logger if ENV.key?('DEBUG')
 
-def debug_message(foo)
-
+def debug_message(message)
+  ENV.key?('DEBUG') ? Log4r::Logger['Thumbs'].debug(message) : nil
 end
 include Thumbs
 
@@ -31,7 +31,19 @@ end
 def cassette(name, options={}, &block)
   VCR.use_cassette(name, options, &block)
 end
-
+def default_vcr_state(&block)
+  cassette(:load_pull_request, :allow_playback_repeats => true) do
+    cassette(:load_comments, :record => :new_episodes, :allow_playback_repeats => true) do
+      cassette(:get_comments_issues, :record => :new_episodes, :allow_playback_repeats => true) do
+        cassette(:get_events, :record => :all, :allow_playback_repeats => true) do
+          cassette(:get_pull_events, :record => :all, :allow_playback_repeats => true) do
+            block.call
+          end
+        end
+      end
+    end
+  end
+end
 def create_test_pr(repo_name)
   # prep test data
   build_dir='/tmp/thumbs'


### PR DESCRIPTION
This makes so that each push invalidates previous reviews. 
Comments counted as code reviews if they are:
- non-author
- contain +1
- occur _after_ the most recent sha push

Target branch set to fix_test_suite as it contains dependant changes, will wait until that merges then switch the target in this pr.

Example of the behavior:
- current: https://github.com/davidx/prtester/pull/241 
- desired: https://github.com/davidx/prtester/pull/240 
