### PR TITLE
Use comments to retain in_progress state to fix racecondition

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'git'
 gem 'unicorn'
 gem 'netrc'
 gem 'activesupport'
-
+gem 'nokogiri', '1.6.8.1'
 
 group :test, :development do
   gem 'vcr'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,12 +63,10 @@ GEM
     multipart-post (2.0.0)
     mustermann (1.0.0.beta2)
     netrc (0.11.0)
-    nokogiri (1.6.8)
+    nokogiri (1.6.8.1)
       mini_portile2 (~> 2.1.0)
-      pkg-config (~> 1.1.7)
     octokit (4.3.0)
       sawyer (~> 0.7.0, >= 0.5.3)
-    pkg-config (1.1.7)
     power_assert (0.3.1)
     rack (2.0.1)
     rack-protection (2.0.0.beta2)
@@ -146,6 +144,7 @@ DEPENDENCIES
   http
   log4r
   netrc
+  nokogiri (= 1.6.8.1)
   octokit
   rack
   rack-test
@@ -158,4 +157,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.12.5
+   1.13.6

--- a/app.rb
+++ b/app.rb
@@ -36,10 +36,7 @@ class ThumbsWeb < Sinatra::Base
   post '/webhook' do
     @octo_client = Octokit::Client.new(:netrc => true)
     payload = JSON.parse(request.body.read)
-    print "\n\n##############################################PAYLOAD#########\n"
-    print payload.to_yaml
-    print "##############################################PAYLOAD#########\n"
-    print "\n"
+    print payload.to_yaml if ENV.key?('DEBUG')
     case payload_type(payload)
       when :new_pr
         repo, pr = process_payload(payload)

--- a/lib/thumbs/pull_request_worker.rb
+++ b/lib/thumbs/pull_request_worker.rb
@@ -11,13 +11,13 @@ module Thumbs
     attr_reader :pr
     attr_accessor :thumb_config
     attr_reader :log
-    attr_reader :client
+    attr_accessor :client
 
     def initialize(options)
       @repo = options[:repo]
       @client = Octokit::Client.new(:netrc => true)
       @pr = @client.pull_request(options[:repo], options[:pr])
-      @build_dir=options[:build_dir] || "/tmp/thumbs/#{@repo.gsub(/\//, '_')}_#{@pr.head.sha.slice(0, 8)}"
+      @build_dir=options[:build_dir] || "/tmp/thumbs/#{@repo.gsub(/\//, '_')}_#{@pr.head.sha.slice(0, 10)}"
       @build_status={:steps => {}}
       @build_steps = []
       prepare_build_dir
@@ -105,7 +105,7 @@ module Thumbs
       status[:command] = command
 
       begin
-        Timeout::timeout(@timeout) do
+        Timeout::timeout(thumb_config['timeout']) do
           output = `#{command}`
           status[:ended_at]=DateTime.now
           unless $? == 0
@@ -139,11 +139,11 @@ module Thumbs
     end
 
     def events
-      client.repository_events(@repo).collect{|e| e.to_h }
+      client.repository_events(@repo).collect { |e| e.to_h }
     end
 
     def push_time_stamp(sha)
-      time_stamp=events.collect { |e| e[:created_at] if e[:type] == 'PushEvent' && e[:payload][:head] == sha}.compact.first
+      time_stamp=events.collect { |e| e[:created_at] if e[:type] == 'PushEvent' && e[:payload][:head] == sha }.compact.first
       time_stamp ? time_stamp : pr.created_at
     end
 
@@ -157,6 +157,7 @@ module Thumbs
     def all_comments
       client.issue_comments(repo, pr.number)
     end
+
     def comments
       comments_after_head_sha
     end
@@ -274,24 +275,119 @@ module Thumbs
       return true
     end
 
-    def run_build_steps
-      build_steps.each do |build_step|
-        build_step_name=build_step.gsub(/\s+/, '_').gsub(/-/, '')
-        try_run_build_step(build_step_name, build_step)
-      end
-      persist_build_status(@repo, @pr.head.sha)
+    def build_in_progress?
+      [:in_progress, :completed].include?(build_progress_status)
     end
 
-    def persist_build_status(repo, rev)
-      repo=repo.gsub(/\//, '_')
-      file=File.join('/tmp/thumbs', "#{repo}_#{rev}.yml")
+    def build_progress_status
+      build_progress_comment = get_build_progress_comment
+      debug_message "got build_progress_comment #{build_progress_comment}"
+      return :unstarted unless build_progress_comment
+      return :unstarted unless build_progress_comment.kind_of?(Hash) && build_progress_comment.key?(:body)
+
+      progress_status_line = build_progress_comment[:body].split(/\n/).shift
+      return :unstarted unless build_progress_comment[:body].length > 0
+      progress_status = progress_status_line.split(/:/).pop
+
+      unless progress_status
+        debug_message "go"
+        return :unstarted
+      end
+
+      progress_status = progress_status.strip.to_sym
+
+      ([:in_progress, :completed].include?(progress_status) ? progress_status : :unstarted)
+    end
+
+    def set_build_progress(progress_status)
+      update_or_create_build_status(most_recent_sha, progress_status)
+    end
+    def compose_build_status_comment_title(sha,status)
+      "[#{sha.slice(0, 10)}] Build Status: #{ status }"
+    end
+    def set_build_status_comment(sha, status)
+      #final check that sha comment doesnt already exist
+      comment = get_build_progress_comment
+      unless comment.key?(:id)
+        add_comment(compose_build_status_comment_title(sha,status))
+      end
+    end
+
+    def comments_after_sha(sha)
+      sha_time_stamp=push_time_stamp(sha)
+      comments_after_sha=all_comments.compact.collect do |c|
+        c.to_h if c[:created_at] > sha_time_stamp
+      end.compact
+    end
+
+    def update_or_create_build_status(sha, progress_status)
+      if build_progress_status == :unstarted
+        set_build_status_comment(sha, progress_status)
+      else
+        comment=get_build_progress_comment
+        comment_id = comment[:id]
+        debug_message "comment id is #{comment_id}"
+        comment_message=compose_build_status_comment_title(sha,progress_status)
+        debug_message comment_message
+        update_pull_request_comment(comment_id, comment_message)
+      end
+    end
+
+    def update_pull_request_comment(comment_id, comment_message)
+      # ensure comment_id exists
+      #Octokit::Client.new(:netrc => true)
+      comment = client.issue_comment(repo, comment_id)
+      unless comment
+        debug_message "comment doesnt exist ?"
+        exit
+      end
+
+      client.update_comment(repo, comment[:id], comment_message)
+    end
+    def clear_build_progress_comment
+      build_progress_comment = get_build_progress_comment
+      build_progress_comment ? client.delete_comment(repo, build_progress_comment[:id]) : true
+    end
+    def get_build_progress_comment
+      bot_comments.collect { |c| c if c[:body] =~ /^\[#{most_recent_sha.slice(0, 10)}/ }.compact[0] || {:body => ""}
+    end
+
+    def pushes
+      events.collect { |e| e if e[:type] == 'PushEvent' }.compact
+    end
+
+    def most_recent_sha
+      return pr.head.sha unless pushes.length > 0
+      pushes.last[:payload][:head]
+    end
+
+    def run_build_steps
+      unless build_in_progress?
+        set_build_progress(:in_progress)
+        build_steps.each do |build_step|
+          build_step_name=build_step.gsub(/\s+/, '_').gsub(/-/, '')
+          try_run_build_step(build_step_name, build_step)
+        end
+        persist_build_status
+        set_build_progress(:completed)
+        create_build_status_comment
+      end
+    end
+
+    def persist_build_status
+      repo=@repo.gsub(/\//, '_')
+      file=File.join('/tmp/thumbs', "#{repo}_#{most_recent_sha}.yml")
       FileUtils.mkdir_p('/tmp/thumbs')
       File.open(file, "w") do |f|
         f.syswrite(@build_status.to_yaml)
       end
       true
     end
-
+    def unpersist_build_status
+      repo=@repo.gsub(/\//, '_')
+      file=File.join('/tmp/thumbs', "#{repo}_#{most_recent_sha}.yml")
+      File.delete(file) if File.exist?(file)
+    end
     def read_build_status(repo, rev)
       repo=repo.gsub(/\//, '_')
       file=File.join('/tmp/thumbs', "#{repo}_#{rev}.yml")
@@ -304,15 +400,17 @@ module Thumbs
 
     def validate
       @build_status = read_build_status(@repo, @pr.head.sha)
-      refresh_repo
-      unless @build_status.key?(:steps) && @build_status[:steps].keys.length > 0
-        debug_message "no build status found, running build steps"
-        try_merge
-        run_build_steps
-      else
-        debug_message "using persisted build status"
+      unless build_in_progress?
+        refresh_repo
+        unless @build_status.key?(:steps) && @build_status[:steps].keys.length > 0
+          debug_message "no build status found, running build steps"
+          try_merge
+          run_build_steps
+        else
+          debug_message "using persisted build status"
+        end
+        true
       end
-      true
     end
 
     def merge
@@ -443,8 +541,7 @@ module Thumbs
         @status_title="Looks like there's an issue with build step #{build_status_problem_steps.join(",")} !  :cloud: "
       end
 
-      comment = render_template <<-EOS
-<p>Build Status: [<%= @pr.head.sha.slice(0,10) %>] <%= @status_title %></p>
+      build_comment = render_template <<-EOS
 <% @build_status[:steps].each do |step_name, status| %>
 <% if status[:output] %>
 <% title_file = step_name.to_s.gsub(/\\//,'_') +  ".txt" %>
@@ -480,7 +577,11 @@ module Thumbs
 <% end %>
 <%= render_reviewers_comment_template %>
       EOS
-      add_comment(comment)
+      comment_id = get_build_progress_comment[:id]
+      comment_message = compose_build_status_comment_title(most_recent_sha, :completed)
+      comment_message << "\n#{@status_title}"
+      comment_message << build_comment
+      update_pull_request_comment(comment_id, comment_message)
     end
 
     def render_reviewers_comment_template

--- a/test/test.rb
+++ b/test/test.rb
@@ -8,4 +8,5 @@ require 'test/test_webhook'
 require 'test/test_payload'
 require 'test/test_persisted_build_status'
 require 'test/test_build_steps'
+#require 'test/test_state'
 

--- a/test/test.rb
+++ b/test/test.rb
@@ -8,5 +8,5 @@ require 'test/test_webhook'
 require 'test/test_payload'
 require 'test/test_persisted_build_status'
 require 'test/test_build_steps'
-#require 'test/test_state'
+require 'test/test_state'
 

--- a/test/test_build_steps.rb
+++ b/test/test_build_steps.rb
@@ -191,6 +191,7 @@ unit_tests do
       prw.respond_to?(:build_steps)
       prw.reset_build_status
       prw.unpersist_build_status
+      assert prw.build_status[:steps] == {}, prw.build_status[:steps].inspect
 
       assert prw.build_steps.sort == ["make", "make test"].sort, prw.build_steps.inspect
       prw.run_build_steps
@@ -202,6 +203,7 @@ unit_tests do
       prw.build_steps = ["make build", "make custom"]
       assert prw.build_steps.include?("make build")
       prw.run_build_steps
+
       assert prw.build_status[:steps].keys.sort == [:make_build, :make_custom].sort, prw.build_status[:steps].keys.sort.inspect
 
       prw.reset_build_status

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -15,6 +15,7 @@ TESTPR=453
 ORGTESTREPO='basho-bin/tester'
 ORGTEST_PRW=Thumbs::PullRequestWorker.new(:repo => TESTREPO, :pr => 27)
 ORGTESTPR=27
+TESTUNMERGABLEPR=452
 Thumbs.start_logger if ENV.key?('DEBUG')
 
 def debug_message(message)
@@ -35,9 +36,11 @@ def default_vcr_state(&block)
   cassette(:load_pull_request, :allow_playback_repeats => true) do
     cassette(:load_comments, :record => :new_episodes, :allow_playback_repeats => true) do
       cassette(:get_comments_issues, :record => :new_episodes, :allow_playback_repeats => true) do
-        cassette(:get_events, :record => :all, :allow_playback_repeats => true) do
-          cassette(:get_pull_events, :record => :all, :allow_playback_repeats => true) do
+        cassette(:get_events_other, :allow_playback_repeats => true) do
+          cassette(:get_events, :allow_playback_repeats => true, :record => :new_episodes) do
+            cassette(:get_pull_events, :record => :all, :allow_playback_repeats => true) do
             block.call
+            end
           end
         end
       end
@@ -149,4 +152,6 @@ module Octokit
     end
   end
 end
+
+
 

--- a/test/test_persisted_build_status.rb
+++ b/test/test_persisted_build_status.rb
@@ -2,7 +2,7 @@
 unit_tests do
 
   test "should be able to read build status" do
-    # can get build status from build status persistence
+   default_vcr_state do
     cassette(:load_pr) do
       prw=Thumbs::PullRequestWorker.new(:repo=>TESTREPO, :pr=>TESTPR)
       assert prw.build_status.key?(:steps)
@@ -20,11 +20,13 @@ unit_tests do
         assert status[:steps].key?(:make), status[:steps].inspect
         assert status[:steps].key?(:make_test), status[:steps].inspect
 
-        assert prw.build_status[:steps].keys.length == [:merge, :make, :make_test].length
+        assert prw.build_status[:steps].keys.length == [:merge, :make, :make_test].length, prw.build_status[:steps].keys
 
       end
 
     end
+   end
+
   end
 end
 

--- a/test/test_persisted_build_status.rb
+++ b/test/test_persisted_build_status.rb
@@ -9,18 +9,23 @@ unit_tests do
       assert prw.build_status[:steps].key?(:merge)
       assert prw.build_status[:steps].keys.length == 1
 
-      prw.run_build_steps
-
       cassette(:read_build_status) do
 
-        status = prw.read_build_status(prw.repo, prw.pr.head.sha)
+        prw.run_build_steps
+
+        status = prw.read_build_status(prw.repo, prw.most_recent_sha)
+        repo=prw.repo.gsub(/\//, '_')
+        file=File.join('/tmp/thumbs', "#{repo}_#{prw.most_recent_sha}.yml")
+
+        parsed_file = File.exist?(file) ?  YAML.load(IO.read(file)) : nil
+        assert parsed_file.keys.sort == status.keys.sort
         assert status.kind_of?(Hash)
         assert status.key?(:steps)
         assert status[:steps].key?(:merge)
         assert status[:steps].key?(:make), status[:steps].inspect
         assert status[:steps].key?(:make_test), status[:steps].inspect
 
-        assert prw.build_status[:steps].keys.length == [:merge, :make, :make_test].length, prw.build_status[:steps].keys
+        assert prw.build_status[:steps].keys.length == [:merge, :make, :make_test].length, prw.build_status[:steps].keys.inspect
 
       end
 

--- a/test/test_state.rb
+++ b/test/test_state.rb
@@ -1,0 +1,68 @@
+unit_tests do
+  test "can read build progress status" do
+    default_vcr_state do
+      prw=Thumbs::PullRequestWorker.new(:repo => TESTREPO, :pr => TESTPR)
+      cassette(:clear_build_comment, :allow_playback_repeats => true, :record => :all) do
+        prw.clear_build_progress_comment
+
+      assert_equal :unstarted, prw.build_progress_status
+      # reset build status
+      prw.build_steps=["find /tmp"]
+      prw.thumb_config['timeout']=5
+      prw.run_build_steps
+      sleep 2
+      assert_equal :completed, prw.build_progress_status
+      end
+
+    end
+  end
+
+
+  test "can get pushes" do
+    default_vcr_state do
+      prw=Thumbs::PullRequestWorker.new(:repo => TESTREPO, :pr => TESTPR)
+      pushes = prw.events.collect { |e| e if e[:type] == 'PushEvent' }.compact
+      assert_equal pushes, prw.pushes
+    end
+  end
+
+  test "can get most_recent_sha" do
+    default_vcr_state do
+      prw=Thumbs::PullRequestWorker.new(:repo => TESTREPO, :pr => TESTPR)
+
+      assert_equal prw.pr.head.sha, prw.most_recent_sha
+    end
+
+  end
+
+  test "set build progress when running build steps" do
+    cassette(:load_stuff, :allow_playback_repeats => true) do
+      prw=Thumbs::PullRequestWorker.new(:repo => TESTREPO, :pr => TESTPR)
+      cassette(:load_stuff_other, :allow_playback_repeats => true) do
+        cassette(:build_progress_steps, :allow_playback_repeats => true, :record => :all) do
+
+
+          default_vcr_state do
+            prw.clear_build_progress_comment
+
+            cassette(:build_in_progress_test, :allow_playback_repeats => true, :record => :all) do
+              cassette(:build_in_progress_test2, :allow_playback_repeats => true, :record => :all) do
+
+                assert_false prw.build_in_progress?
+
+                assert_equal :unstarted, prw.build_progress_status
+                prw.build_steps=["find /tmp"]
+                prw.thumb_config['timeout']=5
+                prw.run_build_steps
+                assert_equal :completed, prw.build_progress_status
+
+              end
+            end
+
+          end
+        end
+      end
+    end
+  end
+end
+

--- a/test/test_state.rb
+++ b/test/test_state.rb
@@ -5,13 +5,8 @@ unit_tests do
       cassette(:clear_build_comment, :allow_playback_repeats => true, :record => :all) do
         prw.clear_build_progress_comment
 
-      assert_equal :unstarted, prw.build_progress_status
-      # reset build status
-      prw.build_steps=["find /tmp"]
-      prw.thumb_config['timeout']=5
-      prw.run_build_steps
-      sleep 2
-      assert_equal :completed, prw.build_progress_status
+        assert_equal :unstarted, prw.build_progress_status
+
       end
 
     end
@@ -53,7 +48,9 @@ unit_tests do
                 assert_equal :unstarted, prw.build_progress_status
                 prw.build_steps=["find /tmp"]
                 prw.thumb_config['timeout']=5
-                prw.run_build_steps
+                prw.set_build_progress(:in_progress)
+                assert_equal :in_progress, prw.build_progress_status
+                prw.set_build_progress(:completed)
                 assert_equal :completed, prw.build_progress_status
 
               end

--- a/test/test_webhook.rb
+++ b/test/test_webhook.rb
@@ -78,6 +78,7 @@ class WebhookTest < Test::Unit::TestCase
                   assert prw.open?
                   new_review_count = prw.review_count
                 end
+                assert_equal :completed, prw.build_progress_status
               end
             end
           end


### PR DESCRIPTION
Adds state for loose locking when build is in progress, and to display state to user.
- fixes issues when build is in progress and it gets triggered again, local state lock file would not scale, this uses github comments so should be able to work across servers.
