### PR TITLE
test bad utf8 characters

### DIFF
--- a/lib/thumbs/pull_request_worker.rb
+++ b/lib/thumbs/pull_request_worker.rb
@@ -385,8 +385,7 @@ module Thumbs
       build_status[:steps].keys.each do |build_step|
         next unless build_status[:steps][build_step].key?(:output)
         output = build_status[:steps][build_step][:output]
-        output.encode!('UTF-8', 'UTF-8', :invalid => :replace, :undef => :replace)
-        build_status[:steps][build_step][:output] = output
+        build_status[:steps][build_step][:output] = sanitize_text(output)
       end
       File.open(file, "w") do |f|
         f.syswrite(build_status.to_yaml)

--- a/test/data/test_utf8_build_status.txt
+++ b/test/data/test_utf8_build_status.txt
@@ -1,0 +1,4 @@
+bitcask_qc_fsm:129: qc_test_.......Corrupting from 255 to <<0>> at 16 size 18
+............................................................Corrupting from 255 to <<0>> at 223 size 227
+.........Corrupting from 255 to <<0>> at 136 size 140
+.........................Corrupting from 0 to <<�>> at 72 size 103 hi "\255"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -154,4 +154,14 @@ module Octokit
 end
 
 
+module Test
+  module Unit
+    def assert_nothing_raised(*)
+      yield
+    end
+  end
+end
+
+
+
 

--- a/test/test_persisted_build_status.rb
+++ b/test/test_persisted_build_status.rb
@@ -1,4 +1,5 @@
 
+
 unit_tests do
 
   test "should be able to read build status" do
@@ -26,12 +27,49 @@ unit_tests do
         assert status[:steps].key?(:make_test), status[:steps].inspect
 
         assert prw.build_status[:steps].keys.length == [:merge, :make, :make_test].length, prw.build_status[:steps].keys.inspect
-
       end
-
     end
    end
 
   end
+  test "should be able to persist build status with utf8 and other bad characters" do
+    default_vcr_state do
+      cassette(:load_pr) do
+        prw=Thumbs::PullRequestWorker.new(:repo=>TESTREPO, :pr=>TESTPR)
+        prw.run_build_steps
+        test_content=IO.read(File.join(File.dirname(__FILE__), "/data/test_utf8_build_status.txt"))
+        prw.build_status[:steps][:make][:output] = test_content
+        prw.persist_build_status
+        status = prw.read_build_status(prw.repo, prw.most_recent_sha)
+        assert_equal prw.build_status[:steps][:make], status[:steps][:make]
+      end
+    end
+  end
+  def sanitize_text(text)
+    text.encode('UTF-8', 'UTF-8', :invalid => :replace, :undef => :replace)
+  end
+  test "should fix bad utf8 byte sequence" do
+    bad_test_string="hi \255"
+    assert_raise(ArgumentError) do
+      test_split = bad_test_string.split(' ')
+    end
+
+    fixed_bad_test_string=sanitize_text(bad_test_string)
+    test_split = fixed_bad_test_string.split(' ')
+    default_vcr_state do
+      cassette(:load_pr) do
+        prw=Thumbs::PullRequestWorker.new(:repo=>TESTREPO, :pr=>TESTPR)
+        prw.run_build_steps
+        prw.build_status[:steps][:make][:output]=bad_test_string
+
+        prw.persist_build_status
+        fixed_persisted_bad_test_string = prw.read_build_status(prw.repo, prw.most_recent_sha)[:steps][:make][:output]
+        assert_equal "hi �", fixed_persisted_bad_test_string
+      end
+    end
+
+  end
 end
+
+
 


### PR DESCRIPTION
This fixes an issue where thumbs hung or crashed a worker after it was unable to convert a piece of text to yaml due to an argumenterror thrown from a bad utf8 character.

It sanitizes the text when setting the build status as well as when persisting.
