### PR TITLE
Rerun build when pr base changes.

### DIFF
--- a/.thumbs.yml
+++ b/.thumbs.yml
@@ -1,7 +1,6 @@
 minimum_reviewers: 2
 merge: false
 build_steps:
- - env
  - bundle exec ruby test/test.rb
 org_mode: true
 timeout: 1799

--- a/.thumbs.yml
+++ b/.thumbs.yml
@@ -1,5 +1,5 @@
 minimum_reviewers: 2
-merge: true
+merge: false
 build_steps:
  - env
  - bundle exec ruby test/test.rb

--- a/lib/thumbs/pull_request_worker.rb
+++ b/lib/thumbs/pull_request_worker.rb
@@ -572,9 +572,9 @@ module Thumbs
 
     def create_build_status_comment
       if aggregate_build_status_result == :ok
-        @status_title="Looks good!  :+1:"
+        @status_title="\n> Looks good!  :+1: |"
       else
-        @status_title="Looks like there's an issue with build step #{build_status_problem_steps.join(",")} !  :cloud: "
+        @status_title="\n> There seems to be an issue with build step **#{build_status_problem_steps.join(",")}** !  :cloud: "
       end
 
       build_comment = render_template <<-EOS

--- a/lib/thumbs/pull_request_worker.rb
+++ b/lib/thumbs/pull_request_worker.rb
@@ -572,7 +572,7 @@ module Thumbs
 
     def create_build_status_comment
       if aggregate_build_status_result == :ok
-        @status_title="\n<details><Summary>**Looks good!**  :+1: </Summary>"
+        @status_title="\n<details><Summary>Looks good!  :+1: </Summary>"
       else
         @status_title="\n<details><Summary>There seems to be an issue with build step **#{build_status_problem_steps.join(",")}** !  :cloud: </Summary>"
       end

--- a/lib/thumbs/pull_request_worker.rb
+++ b/lib/thumbs/pull_request_worker.rb
@@ -572,9 +572,9 @@ module Thumbs
 
     def create_build_status_comment
       if aggregate_build_status_result == :ok
-        @status_title="\n> Looks good!  :+1: |"
+        @status_title="\n<details><Summary>**Looks good!**  :+1: </Summary>"
       else
-        @status_title="\n> There seems to be an issue with build step **#{build_status_problem_steps.join(",")}** !  :cloud: "
+        @status_title="\n<details><Summary>There seems to be an issue with build step **#{build_status_problem_steps.join(",")}** !  :cloud: </Summary>"
       end
 
       build_comment = render_template <<-EOS
@@ -612,6 +612,8 @@ module Thumbs
 
 <% end %>
 <%= render_reviewers_comment_template %>
+
+</details>
       EOS
       comment_id = get_build_progress_comment[:id]
       comment_message = compose_build_status_comment_title(:completed)

--- a/lib/thumbs/pull_request_worker.rb
+++ b/lib/thumbs/pull_request_worker.rb
@@ -300,7 +300,7 @@ module Thumbs
     end
 
     def build_guid
-      "#{repo.split(/\//).pop}:#{pr.base.ref}:#{pr.base.sha.slice(0,7)}:#{pr.head.ref}:#{most_recent_sha.slice(0,7)}"
+      "#{pr.base.ref}:#{pr.base.sha.slice(0,7)}:#{pr.head.ref}:#{most_recent_sha.slice(0,7)}"
     end
     def set_build_progress(progress_status)
       update_or_create_build_status(most_recent_sha, progress_status)

--- a/lib/thumbs/pull_request_worker.rb
+++ b/lib/thumbs/pull_request_worker.rb
@@ -284,13 +284,13 @@ module Thumbs
       debug_message "got build_progress_comment #{build_progress_comment}"
       return :unstarted unless build_progress_comment
       return :unstarted unless build_progress_comment.kind_of?(Hash) && build_progress_comment.key?(:body)
-
-      progress_status_line = build_progress_comment[:body].split(/\n/).shift
       return :unstarted unless build_progress_comment[:body].length > 0
-      progress_status = progress_status_line.split(/:/).pop
+
+      progress_status_line = build_progress_comment[:body].lines[2]
+      progress_status = progress_status_line.split(/\|/).pop.split(/\s+/).pop
 
       unless progress_status
-        debug_message "go"
+        debug_message "invalid"
         return :unstarted
       end
 
@@ -306,8 +306,12 @@ module Thumbs
       update_or_create_build_status(most_recent_sha, progress_status)
     end
 
-    def compose_build_status_comment_title(status)
-      "[ #{build_guid.gsub(/:/,' ')}] Build Status: #{ status }"
+    def compose_build_status_comment_title(progress_status)
+      status_emoji=(progress_status==:completed ? result_image(aggregate_build_status_result) : result_image(progress_status))
+      comment_title="|||||\n"
+      comment_title<<"------------ | -------------|------------ | ------------- | -------------\n"
+      comment_title<<"#{pr.head.ref} #{most_recent_sha.slice(0,7)} | :arrow_right: | #{pr.base.ref} #{pr.base.sha.slice(0,7)} | #{status_emoji} #{progress_status}"
+      comment_title
     end
 
     def set_build_status_comment(sha, status)
@@ -316,6 +320,15 @@ module Thumbs
       unless comment.key?(:id)
         add_comment(compose_build_status_comment_title(status))
       end
+    end
+
+    def get_build_progress_comment
+      bot_comments.collect do |c|
+        next unless c[:body].lines.length > 1
+        status_line = c[:body].lines[2]
+        next unless status_line =~ /^#{pr.head.ref} #{most_recent_sha.slice(0,7)} \| :arrow_right: \| #{pr.base.ref} #{pr.base.sha.slice(0,7)}/
+        c
+      end.compact[0] || {:body => ""}
     end
 
     def comments_after_sha(sha)
@@ -361,9 +374,7 @@ module Thumbs
       build_progress_comment ? client.delete_comment(repo, build_progress_comment[:id]) : true
     end
 
-    def get_build_progress_comment
-      bot_comments.collect { |c| c if c[:body] =~ /^\[ #{build_guid.gsub(/:/, ' ')}/ }.compact[0] || {:body => ""}
-    end
+
 
     def pushes
       events.collect { |e| e if e[:type] == 'PushEvent' }.compact
@@ -561,9 +572,9 @@ module Thumbs
 
     def create_build_status_comment
       if aggregate_build_status_result == :ok
-        @status_title="Looks good!  :+1:"
+        @status_title="\n<details><Summary>**Looks good!**  :+1: </Summary>"
       else
-        @status_title="Looks like there's an issue with build step #{build_status_problem_steps.join(",")} !  :cloud: "
+        @status_title="\n<details><Summary>There seems to be an issue with build step **#{build_status_problem_steps.join(",")}** !  :cloud: </Summary>"
       end
 
       build_comment = render_template <<-EOS
@@ -601,6 +612,8 @@ module Thumbs
 
 <% end %>
 <%= render_reviewers_comment_template %>
+
+</details>
       EOS
       comment_id = get_build_progress_comment[:id]
       comment_message = compose_build_status_comment_title(:completed)
@@ -662,6 +675,8 @@ module Thumbs
 
     def result_image(result)
       case result
+        when :in_progress
+           ":clock1:"
         when :ok
           ":white_check_mark:"
         when :warning

--- a/lib/thumbs/webhook_helpers.rb
+++ b/lib/thumbs/webhook_helpers.rb
@@ -7,11 +7,18 @@ module Sinatra
       return :new_pr if payload['action']=='opened' && payload.key?('pull_request') && payload['pull_request'].key?('number')
       return :new_comment if payload.key?('comment') && payload.key?('issue') && payload['comment'].key?('body')
       return :new_push if payload['action']=='synchronize'
+      return :new_base if payload['action']=='edited' &&
+          payload.key?('changes') &&
+          payload['changes'].key?('base') &&
+          payload['changes']['base'].key?('ref') &&
+          payload['changes']['base']['ref'].key?('from')
       :unregistered
     end
 
     def process_payload(payload)
       case payload_type(payload)
+        when :new_base
+          [payload['repository']['full_name'], payload['pull_request']['number']]
         when :new_push
           [payload['repository']['full_name'], payload['pull_request']['number']]
         when :new_pr

--- a/test/fixtures/edit_pr.yml
+++ b/test/fixtures/edit_pr.yml
@@ -1,0 +1,398 @@
+action: edited
+number: 252
+pull_request:
+  url: https://api.github.com/repos/davidx/prtester/pulls/252
+  id: 90691454
+  html_url: https://github.com/davidx/prtester/pull/252
+  diff_url: https://github.com/davidx/prtester/pull/252.diff
+  patch_url: https://github.com/davidx/prtester/pull/252.patch
+  issue_url: https://api.github.com/repos/davidx/prtester/issues/252
+  number: 252
+  state: open
+  locked: false
+  title: whaat
+  user:
+    login: davidx
+    id: 17162
+    avatar_url: https://avatars.githubusercontent.com/u/17162?v=3
+    gravatar_id: ''
+    url: https://api.github.com/users/davidx
+    html_url: https://github.com/davidx
+    followers_url: https://api.github.com/users/davidx/followers
+    following_url: https://api.github.com/users/davidx/following{/other_user}
+    gists_url: https://api.github.com/users/davidx/gists{/gist_id}
+    starred_url: https://api.github.com/users/davidx/starred{/owner}{/repo}
+    subscriptions_url: https://api.github.com/users/davidx/subscriptions
+    organizations_url: https://api.github.com/users/davidx/orgs
+    repos_url: https://api.github.com/users/davidx/repos
+    events_url: https://api.github.com/users/davidx/events{/privacy}
+    received_events_url: https://api.github.com/users/davidx/received_events
+    type: User
+    site_admin: false
+  body: ''
+  created_at: '2016-10-24T20:58:24Z'
+  updated_at: '2016-10-24T21:12:48Z'
+  closed_at:
+  merged_at:
+  merge_commit_sha: 364e7b541c895bc53faa671054e4a66915bb1a82
+  assignee:
+  assignees: []
+  milestone:
+  commits_url: https://api.github.com/repos/davidx/prtester/pulls/252/commits
+  review_comments_url: https://api.github.com/repos/davidx/prtester/pulls/252/comments
+  review_comment_url: https://api.github.com/repos/davidx/prtester/pulls/comments{/number}
+  comments_url: https://api.github.com/repos/davidx/prtester/issues/252/comments
+  statuses_url: https://api.github.com/repos/davidx/prtester/statuses/eec6cb8debc99a877938517527c232d607bed39b
+  head:
+    label: davidx:1477342513
+    ref: '1477342513'
+    sha: eec6cb8debc99a877938517527c232d607bed39b
+    user:
+      login: davidx
+      id: 17162
+      avatar_url: https://avatars.githubusercontent.com/u/17162?v=3
+      gravatar_id: ''
+      url: https://api.github.com/users/davidx
+      html_url: https://github.com/davidx
+      followers_url: https://api.github.com/users/davidx/followers
+      following_url: https://api.github.com/users/davidx/following{/other_user}
+      gists_url: https://api.github.com/users/davidx/gists{/gist_id}
+      starred_url: https://api.github.com/users/davidx/starred{/owner}{/repo}
+      subscriptions_url: https://api.github.com/users/davidx/subscriptions
+      organizations_url: https://api.github.com/users/davidx/orgs
+      repos_url: https://api.github.com/users/davidx/repos
+      events_url: https://api.github.com/users/davidx/events{/privacy}
+      received_events_url: https://api.github.com/users/davidx/received_events
+      type: User
+      site_admin: false
+    repo:
+      id: 64998050
+      name: prtester
+      full_name: davidx/prtester
+      owner:
+        login: davidx
+        id: 17162
+        avatar_url: https://avatars.githubusercontent.com/u/17162?v=3
+        gravatar_id: ''
+        url: https://api.github.com/users/davidx
+        html_url: https://github.com/davidx
+        followers_url: https://api.github.com/users/davidx/followers
+        following_url: https://api.github.com/users/davidx/following{/other_user}
+        gists_url: https://api.github.com/users/davidx/gists{/gist_id}
+        starred_url: https://api.github.com/users/davidx/starred{/owner}{/repo}
+        subscriptions_url: https://api.github.com/users/davidx/subscriptions
+        organizations_url: https://api.github.com/users/davidx/orgs
+        repos_url: https://api.github.com/users/davidx/repos
+        events_url: https://api.github.com/users/davidx/events{/privacy}
+        received_events_url: https://api.github.com/users/davidx/received_events
+        type: User
+        site_admin: false
+      private: false
+      html_url: https://github.com/davidx/prtester
+      description: testing pr
+      fork: false
+      url: https://api.github.com/repos/davidx/prtester
+      forks_url: https://api.github.com/repos/davidx/prtester/forks
+      keys_url: https://api.github.com/repos/davidx/prtester/keys{/key_id}
+      collaborators_url: https://api.github.com/repos/davidx/prtester/collaborators{/collaborator}
+      teams_url: https://api.github.com/repos/davidx/prtester/teams
+      hooks_url: https://api.github.com/repos/davidx/prtester/hooks
+      issue_events_url: https://api.github.com/repos/davidx/prtester/issues/events{/number}
+      events_url: https://api.github.com/repos/davidx/prtester/events
+      assignees_url: https://api.github.com/repos/davidx/prtester/assignees{/user}
+      branches_url: https://api.github.com/repos/davidx/prtester/branches{/branch}
+      tags_url: https://api.github.com/repos/davidx/prtester/tags
+      blobs_url: https://api.github.com/repos/davidx/prtester/git/blobs{/sha}
+      git_tags_url: https://api.github.com/repos/davidx/prtester/git/tags{/sha}
+      git_refs_url: https://api.github.com/repos/davidx/prtester/git/refs{/sha}
+      trees_url: https://api.github.com/repos/davidx/prtester/git/trees{/sha}
+      statuses_url: https://api.github.com/repos/davidx/prtester/statuses/{sha}
+      languages_url: https://api.github.com/repos/davidx/prtester/languages
+      stargazers_url: https://api.github.com/repos/davidx/prtester/stargazers
+      contributors_url: https://api.github.com/repos/davidx/prtester/contributors
+      subscribers_url: https://api.github.com/repos/davidx/prtester/subscribers
+      subscription_url: https://api.github.com/repos/davidx/prtester/subscription
+      commits_url: https://api.github.com/repos/davidx/prtester/commits{/sha}
+      git_commits_url: https://api.github.com/repos/davidx/prtester/git/commits{/sha}
+      comments_url: https://api.github.com/repos/davidx/prtester/comments{/number}
+      issue_comment_url: https://api.github.com/repos/davidx/prtester/issues/comments{/number}
+      contents_url: https://api.github.com/repos/davidx/prtester/contents/{+path}
+      compare_url: https://api.github.com/repos/davidx/prtester/compare/{base}...{head}
+      merges_url: https://api.github.com/repos/davidx/prtester/merges
+      archive_url: https://api.github.com/repos/davidx/prtester/{archive_format}{/ref}
+      downloads_url: https://api.github.com/repos/davidx/prtester/downloads
+      issues_url: https://api.github.com/repos/davidx/prtester/issues{/number}
+      pulls_url: https://api.github.com/repos/davidx/prtester/pulls{/number}
+      milestones_url: https://api.github.com/repos/davidx/prtester/milestones{/number}
+      notifications_url: https://api.github.com/repos/davidx/prtester/notifications{?since,all,participating}
+      labels_url: https://api.github.com/repos/davidx/prtester/labels{/name}
+      releases_url: https://api.github.com/repos/davidx/prtester/releases{/id}
+      deployments_url: https://api.github.com/repos/davidx/prtester/deployments
+      created_at: '2016-08-05T07:21:52Z'
+      updated_at: '2016-08-05T07:29:52Z'
+      pushed_at: '2016-10-24T21:09:01Z'
+      git_url: git://github.com/davidx/prtester.git
+      ssh_url: git@github.com:davidx/prtester.git
+      clone_url: https://github.com/davidx/prtester.git
+      svn_url: https://github.com/davidx/prtester
+      homepage:
+      size: 216
+      stargazers_count: 0
+      watchers_count: 0
+      language: Makefile
+      has_issues: true
+      has_downloads: true
+      has_wiki: true
+      has_pages: false
+      forks_count: 2
+      mirror_url:
+      open_issues_count: 9
+      forks: 2
+      open_issues: 9
+      watchers: 0
+      default_branch: master
+  base:
+    label: davidx:1473975779
+    ref: '1473975779'
+    sha: 22b8e6034d603fa6ed700487c5ed20886ebfe5ef
+    user:
+      login: davidx
+      id: 17162
+      avatar_url: https://avatars.githubusercontent.com/u/17162?v=3
+      gravatar_id: ''
+      url: https://api.github.com/users/davidx
+      html_url: https://github.com/davidx
+      followers_url: https://api.github.com/users/davidx/followers
+      following_url: https://api.github.com/users/davidx/following{/other_user}
+      gists_url: https://api.github.com/users/davidx/gists{/gist_id}
+      starred_url: https://api.github.com/users/davidx/starred{/owner}{/repo}
+      subscriptions_url: https://api.github.com/users/davidx/subscriptions
+      organizations_url: https://api.github.com/users/davidx/orgs
+      repos_url: https://api.github.com/users/davidx/repos
+      events_url: https://api.github.com/users/davidx/events{/privacy}
+      received_events_url: https://api.github.com/users/davidx/received_events
+      type: User
+      site_admin: false
+    repo:
+      id: 64998050
+      name: prtester
+      full_name: davidx/prtester
+      owner:
+        login: davidx
+        id: 17162
+        avatar_url: https://avatars.githubusercontent.com/u/17162?v=3
+        gravatar_id: ''
+        url: https://api.github.com/users/davidx
+        html_url: https://github.com/davidx
+        followers_url: https://api.github.com/users/davidx/followers
+        following_url: https://api.github.com/users/davidx/following{/other_user}
+        gists_url: https://api.github.com/users/davidx/gists{/gist_id}
+        starred_url: https://api.github.com/users/davidx/starred{/owner}{/repo}
+        subscriptions_url: https://api.github.com/users/davidx/subscriptions
+        organizations_url: https://api.github.com/users/davidx/orgs
+        repos_url: https://api.github.com/users/davidx/repos
+        events_url: https://api.github.com/users/davidx/events{/privacy}
+        received_events_url: https://api.github.com/users/davidx/received_events
+        type: User
+        site_admin: false
+      private: false
+      html_url: https://github.com/davidx/prtester
+      description: testing pr
+      fork: false
+      url: https://api.github.com/repos/davidx/prtester
+      forks_url: https://api.github.com/repos/davidx/prtester/forks
+      keys_url: https://api.github.com/repos/davidx/prtester/keys{/key_id}
+      collaborators_url: https://api.github.com/repos/davidx/prtester/collaborators{/collaborator}
+      teams_url: https://api.github.com/repos/davidx/prtester/teams
+      hooks_url: https://api.github.com/repos/davidx/prtester/hooks
+      issue_events_url: https://api.github.com/repos/davidx/prtester/issues/events{/number}
+      events_url: https://api.github.com/repos/davidx/prtester/events
+      assignees_url: https://api.github.com/repos/davidx/prtester/assignees{/user}
+      branches_url: https://api.github.com/repos/davidx/prtester/branches{/branch}
+      tags_url: https://api.github.com/repos/davidx/prtester/tags
+      blobs_url: https://api.github.com/repos/davidx/prtester/git/blobs{/sha}
+      git_tags_url: https://api.github.com/repos/davidx/prtester/git/tags{/sha}
+      git_refs_url: https://api.github.com/repos/davidx/prtester/git/refs{/sha}
+      trees_url: https://api.github.com/repos/davidx/prtester/git/trees{/sha}
+      statuses_url: https://api.github.com/repos/davidx/prtester/statuses/{sha}
+      languages_url: https://api.github.com/repos/davidx/prtester/languages
+      stargazers_url: https://api.github.com/repos/davidx/prtester/stargazers
+      contributors_url: https://api.github.com/repos/davidx/prtester/contributors
+      subscribers_url: https://api.github.com/repos/davidx/prtester/subscribers
+      subscription_url: https://api.github.com/repos/davidx/prtester/subscription
+      commits_url: https://api.github.com/repos/davidx/prtester/commits{/sha}
+      git_commits_url: https://api.github.com/repos/davidx/prtester/git/commits{/sha}
+      comments_url: https://api.github.com/repos/davidx/prtester/comments{/number}
+      issue_comment_url: https://api.github.com/repos/davidx/prtester/issues/comments{/number}
+      contents_url: https://api.github.com/repos/davidx/prtester/contents/{+path}
+      compare_url: https://api.github.com/repos/davidx/prtester/compare/{base}...{head}
+      merges_url: https://api.github.com/repos/davidx/prtester/merges
+      archive_url: https://api.github.com/repos/davidx/prtester/{archive_format}{/ref}
+      downloads_url: https://api.github.com/repos/davidx/prtester/downloads
+      issues_url: https://api.github.com/repos/davidx/prtester/issues{/number}
+      pulls_url: https://api.github.com/repos/davidx/prtester/pulls{/number}
+      milestones_url: https://api.github.com/repos/davidx/prtester/milestones{/number}
+      notifications_url: https://api.github.com/repos/davidx/prtester/notifications{?since,all,participating}
+      labels_url: https://api.github.com/repos/davidx/prtester/labels{/name}
+      releases_url: https://api.github.com/repos/davidx/prtester/releases{/id}
+      deployments_url: https://api.github.com/repos/davidx/prtester/deployments
+      created_at: '2016-08-05T07:21:52Z'
+      updated_at: '2016-08-05T07:29:52Z'
+      pushed_at: '2016-10-24T21:09:01Z'
+      git_url: git://github.com/davidx/prtester.git
+      ssh_url: git@github.com:davidx/prtester.git
+      clone_url: https://github.com/davidx/prtester.git
+      svn_url: https://github.com/davidx/prtester
+      homepage:
+      size: 216
+      stargazers_count: 0
+      watchers_count: 0
+      language: Makefile
+      has_issues: true
+      has_downloads: true
+      has_wiki: true
+      has_pages: false
+      forks_count: 2
+      mirror_url:
+      open_issues_count: 9
+      forks: 2
+      open_issues: 9
+      watchers: 0
+      default_branch: master
+  _links:
+    self:
+      href: https://api.github.com/repos/davidx/prtester/pulls/252
+    html:
+      href: https://github.com/davidx/prtester/pull/252
+    issue:
+      href: https://api.github.com/repos/davidx/prtester/issues/252
+    comments:
+      href: https://api.github.com/repos/davidx/prtester/issues/252/comments
+    review_comments:
+      href: https://api.github.com/repos/davidx/prtester/pulls/252/comments
+    review_comment:
+      href: https://api.github.com/repos/davidx/prtester/pulls/comments{/number}
+    commits:
+      href: https://api.github.com/repos/davidx/prtester/pulls/252/commits
+    statuses:
+      href: https://api.github.com/repos/davidx/prtester/statuses/eec6cb8debc99a877938517527c232d607bed39b
+  merged: false
+  mergeable:
+  mergeable_state: unknown
+  merged_by:
+  comments: 3
+  review_comments: 0
+  commits: 72
+  additions: 15
+  deletions: 6
+  changed_files: 3
+changes:
+  base:
+    ref:
+      from: master
+    sha:
+      from: afadb0afefe87362ca819a4a78b5bc89dede3133
+repository:
+  id: 64998050
+  name: prtester
+  full_name: davidx/prtester
+  owner:
+    login: davidx
+    id: 17162
+    avatar_url: https://avatars.githubusercontent.com/u/17162?v=3
+    gravatar_id: ''
+    url: https://api.github.com/users/davidx
+    html_url: https://github.com/davidx
+    followers_url: https://api.github.com/users/davidx/followers
+    following_url: https://api.github.com/users/davidx/following{/other_user}
+    gists_url: https://api.github.com/users/davidx/gists{/gist_id}
+    starred_url: https://api.github.com/users/davidx/starred{/owner}{/repo}
+    subscriptions_url: https://api.github.com/users/davidx/subscriptions
+    organizations_url: https://api.github.com/users/davidx/orgs
+    repos_url: https://api.github.com/users/davidx/repos
+    events_url: https://api.github.com/users/davidx/events{/privacy}
+    received_events_url: https://api.github.com/users/davidx/received_events
+    type: User
+    site_admin: false
+  private: false
+  html_url: https://github.com/davidx/prtester
+  description: testing pr
+  fork: false
+  url: https://api.github.com/repos/davidx/prtester
+  forks_url: https://api.github.com/repos/davidx/prtester/forks
+  keys_url: https://api.github.com/repos/davidx/prtester/keys{/key_id}
+  collaborators_url: https://api.github.com/repos/davidx/prtester/collaborators{/collaborator}
+  teams_url: https://api.github.com/repos/davidx/prtester/teams
+  hooks_url: https://api.github.com/repos/davidx/prtester/hooks
+  issue_events_url: https://api.github.com/repos/davidx/prtester/issues/events{/number}
+  events_url: https://api.github.com/repos/davidx/prtester/events
+  assignees_url: https://api.github.com/repos/davidx/prtester/assignees{/user}
+  branches_url: https://api.github.com/repos/davidx/prtester/branches{/branch}
+  tags_url: https://api.github.com/repos/davidx/prtester/tags
+  blobs_url: https://api.github.com/repos/davidx/prtester/git/blobs{/sha}
+  git_tags_url: https://api.github.com/repos/davidx/prtester/git/tags{/sha}
+  git_refs_url: https://api.github.com/repos/davidx/prtester/git/refs{/sha}
+  trees_url: https://api.github.com/repos/davidx/prtester/git/trees{/sha}
+  statuses_url: https://api.github.com/repos/davidx/prtester/statuses/{sha}
+  languages_url: https://api.github.com/repos/davidx/prtester/languages
+  stargazers_url: https://api.github.com/repos/davidx/prtester/stargazers
+  contributors_url: https://api.github.com/repos/davidx/prtester/contributors
+  subscribers_url: https://api.github.com/repos/davidx/prtester/subscribers
+  subscription_url: https://api.github.com/repos/davidx/prtester/subscription
+  commits_url: https://api.github.com/repos/davidx/prtester/commits{/sha}
+  git_commits_url: https://api.github.com/repos/davidx/prtester/git/commits{/sha}
+  comments_url: https://api.github.com/repos/davidx/prtester/comments{/number}
+  issue_comment_url: https://api.github.com/repos/davidx/prtester/issues/comments{/number}
+  contents_url: https://api.github.com/repos/davidx/prtester/contents/{+path}
+  compare_url: https://api.github.com/repos/davidx/prtester/compare/{base}...{head}
+  merges_url: https://api.github.com/repos/davidx/prtester/merges
+  archive_url: https://api.github.com/repos/davidx/prtester/{archive_format}{/ref}
+  downloads_url: https://api.github.com/repos/davidx/prtester/downloads
+  issues_url: https://api.github.com/repos/davidx/prtester/issues{/number}
+  pulls_url: https://api.github.com/repos/davidx/prtester/pulls{/number}
+  milestones_url: https://api.github.com/repos/davidx/prtester/milestones{/number}
+  notifications_url: https://api.github.com/repos/davidx/prtester/notifications{?since,all,participating}
+  labels_url: https://api.github.com/repos/davidx/prtester/labels{/name}
+  releases_url: https://api.github.com/repos/davidx/prtester/releases{/id}
+  deployments_url: https://api.github.com/repos/davidx/prtester/deployments
+  created_at: '2016-08-05T07:21:52Z'
+  updated_at: '2016-08-05T07:29:52Z'
+  pushed_at: '2016-10-24T21:09:01Z'
+  git_url: git://github.com/davidx/prtester.git
+  ssh_url: git@github.com:davidx/prtester.git
+  clone_url: https://github.com/davidx/prtester.git
+  svn_url: https://github.com/davidx/prtester
+  homepage:
+  size: 216
+  stargazers_count: 0
+  watchers_count: 0
+  language: Makefile
+  has_issues: true
+  has_downloads: true
+  has_wiki: true
+  has_pages: false
+  forks_count: 2
+  mirror_url:
+  open_issues_count: 9
+  forks: 2
+  open_issues: 9
+  watchers: 0
+  default_branch: master
+sender:
+  login: davidx
+  id: 17162
+  avatar_url: https://avatars.githubusercontent.com/u/17162?v=3
+  gravatar_id: ''
+  url: https://api.github.com/users/davidx
+  html_url: https://github.com/davidx
+  followers_url: https://api.github.com/users/davidx/followers
+  following_url: https://api.github.com/users/davidx/following{/other_user}
+  gists_url: https://api.github.com/users/davidx/gists{/gist_id}
+  starred_url: https://api.github.com/users/davidx/starred{/owner}{/repo}
+  subscriptions_url: https://api.github.com/users/davidx/subscriptions
+  organizations_url: https://api.github.com/users/davidx/orgs
+  repos_url: https://api.github.com/users/davidx/repos
+  events_url: https://api.github.com/users/davidx/events{/privacy}
+  received_events_url: https://api.github.com/users/davidx/received_events
+  type: User
+  site_admin: false

--- a/test/test.rb
+++ b/test/test.rb
@@ -9,4 +9,5 @@ require 'test/test_payload'
 require 'test/test_persisted_build_status'
 require 'test/test_build_steps'
 require 'test/test_state'
+require 'test/test_common'
 

--- a/test/test_build_steps.rb
+++ b/test/test_build_steps.rb
@@ -26,7 +26,7 @@ unit_tests do
       assert status.key?(:result)
       assert status.key?(:message)
       assert status.key?(:command)
-      assert_equal "cd /tmp/thumbs/thumbot_prtester_#{prw.pr.head.sha.slice(0, 10)} && uptime 2>&1", status[:command]
+      assert_equal "cd /tmp/thumbs/#{prw.build_guid} && uptime 2>&1", status[:command]
       assert status.key?(:output)
 
       assert status.key?(:exit_code)
@@ -71,7 +71,7 @@ unit_tests do
       assert status[:exit_code]==0
       assert status.key?(:result)
       assert status[:result]==:ok
-      build_dir_path="/tmp/thumbs/#{prw.repo.gsub(/\//, '_')}_#{prw.pr.head.sha.slice(0, 10)}"
+      build_dir_path="/tmp/thumbs/#{prw.build_guid}"
       assert_equal "cd #{build_dir_path} && make build 2>&1", status[:command]
 
       assert_equal "BUILD OK\n", status[:output]

--- a/test/test_common.rb
+++ b/test/test_common.rb
@@ -1,0 +1,12 @@
+
+
+unit_tests do
+
+  test "should be able to generate base and sha specific build guid" do
+    default_vcr_state do
+      prw = Thumbs::PullRequestWorker.new(:repo => TESTREPO, :pr => TESTPR)
+      assert prw.respond_to?(:build_guid)
+      assert_equal "#{prw.pr.base.ref}_#{prw.most_recent_sha.slice(0,7)}", prw.build_guid
+    end
+  end
+end

--- a/test/test_common.rb
+++ b/test/test_common.rb
@@ -6,7 +6,7 @@ unit_tests do
     default_vcr_state do
       prw = Thumbs::PullRequestWorker.new(:repo => TESTREPO, :pr => TESTPR)
       assert prw.respond_to?(:build_guid)
-      assert_equal "#{prw.repo.split(/\//).pop}:#{prw.pr.base.ref}:#{prw.pr.base.sha.slice(0,7)}:#{prw.pr.head.ref}:#{prw.most_recent_sha.slice(0,7)}", prw.build_guid
+      assert_equal "#{prw.pr.base.ref}:#{prw.pr.base.sha.slice(0,7)}:#{prw.pr.head.ref}:#{prw.most_recent_sha.slice(0,7)}", prw.build_guid
     end
   end
 

--- a/test/test_common.rb
+++ b/test/test_common.rb
@@ -6,7 +6,25 @@ unit_tests do
     default_vcr_state do
       prw = Thumbs::PullRequestWorker.new(:repo => TESTREPO, :pr => TESTPR)
       assert prw.respond_to?(:build_guid)
-      assert_equal "#{prw.pr.base.ref}_#{prw.most_recent_sha.slice(0,7)}", prw.build_guid
+      assert_equal "#{prw.repo.split(/\//).pop}:#{prw.pr.base.ref}:#{prw.pr.base.sha.slice(0,7)}:#{prw.pr.head.ref}:#{prw.most_recent_sha.slice(0,7)}", prw.build_guid
+    end
+  end
+
+
+  test "can get open pull requests for repo" do
+    default_vcr_state do
+      prw = Thumbs::PullRequestWorker.new(:repo => TESTREPO, :pr => TESTPR)
+      prw.respond_to?(:open_pull_requests)
+      open_pull_requests = prw.client.pull_requests(prw.repo, :state => 'open')
+      assert_equal open_pull_requests.collect{|pr| pr[:base][:ref] }, prw.open_pull_requests.collect{|pr| pr[:base][:ref] }
+    end
+  end
+  test "can get open pull requests for repo and branch" do
+    default_vcr_state do
+      prw = Thumbs::PullRequestWorker.new(:repo => TESTREPO, :pr => TESTPR)
+      prw.respond_to?(:pull_requests_for_base_branch)
+      matched_base_pull_requests = prw.open_pull_requests.collect{|pr| pr if pr.base.ref == "master"}
+      assert_equal matched_base_pull_requests.collect{|pr| pr[:base][:ref] }, prw.pull_requests_for_base_branch("master").collect{|pr| pr[:base][:ref] }
     end
   end
 end

--- a/test/test_payload.rb
+++ b/test/test_payload.rb
@@ -49,4 +49,21 @@ unit_tests do
 
   end
 
+  test "can detect new base payload type" do
+    new_base_payload = {
+        'action' => 'edited',
+        'changes' => {
+            'base' => {
+                'ref' => {
+                  'from' => 'master'
+                },
+                'sha' => {
+                  'from' => 'afadb0afefe87362ca819a4a78b5bc89dede3133'
+                }
+            }
+        }
+    }
+
+    assert payload_type(new_base_payload) == :new_base, payload_type(new_base_payload).to_s
+  end
 end

--- a/test/test_payload.rb
+++ b/test/test_payload.rb
@@ -66,4 +66,5 @@ unit_tests do
 
     assert payload_type(new_base_payload) == :new_base, payload_type(new_base_payload).to_s
   end
+
 end

--- a/test/test_persisted_build_status.rb
+++ b/test/test_persisted_build_status.rb
@@ -14,7 +14,7 @@ unit_tests do
 
         prw.run_build_steps
 
-        status = prw.read_build_status(prw.repo, prw.most_recent_sha)
+        status = prw.read_build_status
         repo=prw.repo.gsub(/\//, '_')
         file=File.join('/tmp/thumbs', "#{repo}_#{prw.most_recent_sha}.yml")
 
@@ -40,7 +40,7 @@ unit_tests do
         test_content=IO.read(File.join(File.dirname(__FILE__), "/data/test_utf8_build_status.txt"))
         prw.build_status[:steps][:make][:output] = test_content
         prw.persist_build_status
-        status = prw.read_build_status(prw.repo, prw.most_recent_sha)
+        status = prw.read_build_status
         assert_equal prw.build_status[:steps][:make], status[:steps][:make]
       end
     end
@@ -63,7 +63,7 @@ unit_tests do
         prw.build_status[:steps][:make][:output]=bad_test_string
 
         prw.persist_build_status
-        fixed_persisted_bad_test_string = prw.read_build_status(prw.repo, prw.most_recent_sha)[:steps][:make][:output]
+        fixed_persisted_bad_test_string = prw.read_build_status[:steps][:make][:output]
         assert_equal "hi �", fixed_persisted_bad_test_string
       end
     end

--- a/test/test_persisted_build_status.rb
+++ b/test/test_persisted_build_status.rb
@@ -36,7 +36,9 @@ unit_tests do
     default_vcr_state do
       cassette(:load_pr) do
         prw=Thumbs::PullRequestWorker.new(:repo=>TESTREPO, :pr=>TESTPR)
-        prw.run_build_steps
+        cassette(:get_events_reload, :record => :new_episodes) do
+
+          prw.run_build_steps
         test_content=IO.read(File.join(File.dirname(__FILE__), "/data/test_utf8_build_status.txt"))
         prw.build_status[:steps][:make][:output] = test_content
         prw.persist_build_status
@@ -44,7 +46,9 @@ unit_tests do
         assert_equal prw.build_status[:steps][:make], status[:steps][:make]
       end
     end
+    end
   end
+
   def sanitize_text(text)
     text.encode('UTF-8', 'UTF-8', :invalid => :replace, :undef => :replace)
   end
@@ -59,12 +63,14 @@ unit_tests do
     default_vcr_state do
       cassette(:load_pr) do
         prw=Thumbs::PullRequestWorker.new(:repo=>TESTREPO, :pr=>TESTPR)
-        prw.run_build_steps
-        prw.build_status[:steps][:make][:output]=bad_test_string
+        cassette(:get_events_reload, :record => :new_episodes) do
+          prw.run_build_steps
+          prw.build_status[:steps][:make][:output]=bad_test_string
 
-        prw.persist_build_status
-        fixed_persisted_bad_test_string = prw.read_build_status[:steps][:make][:output]
-        assert_equal "hi �", fixed_persisted_bad_test_string
+          prw.persist_build_status
+          fixed_persisted_bad_test_string = prw.read_build_status[:steps][:make][:output]
+          assert_equal "hi �", fixed_persisted_bad_test_string
+        end
       end
     end
 

--- a/test/test_state.rb
+++ b/test/test_state.rb
@@ -30,36 +30,4 @@ unit_tests do
 
   end
 
-  test "set build progress when running build steps" do
-    cassette(:load_stuff, :allow_playback_repeats => true) do
-      prw=Thumbs::PullRequestWorker.new(:repo => TESTREPO, :pr => TESTPR)
-      cassette(:load_stuff_other, :allow_playback_repeats => true) do
-        cassette(:build_progress_steps, :allow_playback_repeats => true, :record => :all) do
-
-
-          default_vcr_state do
-            prw.clear_build_progress_comment
-
-            cassette(:build_in_progress_test, :allow_playback_repeats => true, :record => :all) do
-              cassette(:build_in_progress_test2, :allow_playback_repeats => true, :record => :all) do
-
-                assert_false prw.build_in_progress?
-
-                assert_equal :unstarted, prw.build_progress_status
-                prw.build_steps=["find /tmp"]
-                prw.thumb_config['timeout']=5
-                prw.set_build_progress(:in_progress)
-                assert_equal :in_progress, prw.build_progress_status
-                prw.set_build_progress(:completed)
-                assert_equal :completed, prw.build_progress_status
-
-              end
-            end
-
-          end
-        end
-      end
-    end
-  end
 end
-

--- a/test/test_webhook.rb
+++ b/test/test_webhook.rb
@@ -90,10 +90,6 @@ class WebhookTest < Test::Unit::TestCase
     cassette(:load_pr, :record => :new_episodes) do
       prw = Thumbs::PullRequestWorker.new(:repo => 'thumbot/prtester', :pr => TESTPR)
 
-      build_dir="/tmp/thumbs/#{prw.repo.gsub(/\//, '_')}_#{prw.pr.head.sha.slice(0, 10)}"
-      FileUtils.rm_rf(build_dir)
-      assert_equal false, File.exist?(build_dir)
-
       new_pr_webhook_payload = {
           'repository' => {'full_name' => prw.repo},
           'number' => prw.pr.number,
@@ -104,7 +100,6 @@ class WebhookTest < Test::Unit::TestCase
       remove_comments(prw.repo, prw.pr.number)
       cassette(:get_comments, :record => :all) do
         cassette(:get_issue_comments, :record => :all) do
-          original_comments_length=prw.comments.length
 
           cassette(:post_webhook_new_pr, :record => :all) do
 
@@ -173,3 +168,11 @@ end
 
 
 # end
+
+
+#
+# 2.3.0 :015 >   prw.client.pull_requests(prw.repo, :state => 'open').collect{|pr| pr if pr.base.ref == 'master'}.length
+
+
+
+# prw.client.pull_requests(prw.repo, :state => 'open')


### PR DESCRIPTION
This enables support for rerunning build when pr:base changes.
This only currently supports actively changing the base, not "any base changes"  
It lays the groundwork tho for being able to respond properly to the right event.
