### PR TITLE
Automatically rebuild all pull requests after a base gets merged

### DIFF
--- a/.thumbs.yml
+++ b/.thumbs.yml
@@ -1,7 +1,6 @@
 minimum_reviewers: 2
 merge: false
 build_steps:
- - env
  - bundle exec ruby test/test.rb
 org_mode: true
 timeout: 1799

--- a/.thumbs.yml
+++ b/.thumbs.yml
@@ -1,5 +1,5 @@
 minimum_reviewers: 2
-merge: true
+merge: false
 build_steps:
  - env
  - bundle exec ruby test/test.rb

--- a/app.rb
+++ b/app.rb
@@ -49,10 +49,18 @@ class ThumbsWeb < Sinatra::Base
         return "OK" unless pr_worker.open?
         return "OK" if pr_worker.build_in_progress?
         debug_message("new pull request #{pr_worker.repo}/pulls/#{pr_worker.pr.number} ")
-        pr_worker.add_comment("Thanks @#{pr_worker.pr.user.login}!")
-        pr_worker.add_comment " .thumbs.yml config:\n``` #{pr_worker.thumb_config.to_yaml} ```"
-        pr_worker.set_build_progress(:in_progress)
+        intro_text=<<-EOS
+Thanks @#{pr_worker.pr.user.login}!
+<details><Summary>Settings</Summary>
 
+```yaml 
+#{pr_worker.thumb_config.to_yaml} ```
+
+</details>
+        
+        EOS
+        pr_worker.add_comment(intro_text)
+        pr_worker.set_build_progress(:in_progress)
         pr_worker.try_merge
         unless pr_worker.thumb_config && pr_worker.thumb_config.key?('build_steps')
           debug_message("no .thumbs config found for this repo/PR #{pr_worker.repo}##{pr_worker.pr.number}")

--- a/app.rb
+++ b/app.rb
@@ -145,31 +145,27 @@ class ThumbsWeb < Sinatra::Base
         debug_message "got repo #{repo} and base_ref #{base_ref}"
         pull_requests_for_base_branch = @octo_client.pull_requests(repo, :state => 'open').collect{|pr| pr if pr.base.ref == base_ref }.compact
         pull_requests_for_base_branch.each do |pr|
-          debug_message "Rebuilding PR: #{pr.number} with new Base #{base_ref}"
-          debug_message "Unimplemented"
-            # sleep 5
-            # pr_worker=Thumbs::PullRequestWorker.new(:repo => repo, :pr => pr.number)
-            #
-            # if pr_worker.build_in_progress?
-            #   debug_message "PR: #{pr.number} build_in_progress : next"
-            #   return "OK"
-            # end
-            # pr_worker.set_build_progress(:in_progress)
-            # pr_worker.validate
-            # pr_worker.set_build_progress(:completed)
-            # pr_worker.create_build_status_comment
-            #
-            #
-            # if pr_worker.valid_for_merge?
-            #   debug_message("merged base #{pr_worker.repo}/pulls/#{pr_worker.pr.number} valid_for_merge? OK ")
-            #   pr_worker.merge
-            # else
-            #   debug_message("merged base #{pr_worker.repo}/pulls/#{pr_worker.pr.number} valid_for_merge? returned False")
-            # end
-            #
+          debug_message "Forking Rebuild of PR: #{pr.number} with new Base ref #{base_ref}"
+          Process.detach( fork do
+            pr_worker=Thumbs::PullRequestWorker.new(:repo => repo, :pr => pr.number)
+
+            if pr_worker.build_in_progress?
+              debug_message "PR: #{pr.number} build_in_progress : next"
+              return "OK"
+            end
+            pr_worker.set_build_progress(:in_progress)
+            pr_worker.validate
+            pr_worker.set_build_progress(:completed)
+            pr_worker.create_build_status_comment
+
+            if pr_worker.valid_for_merge?
+              debug_message("merged base #{pr_worker.repo}/pulls/#{pr_worker.pr.number} valid_for_merge? OK ")
+              pr_worker.merge
+            else
+              debug_message("merged base #{pr_worker.repo}/pulls/#{pr_worker.pr.number} valid_for_merge? returned False")
+            end
+          end)
         end
-
-
       when :unregistered
         debug_message "This is not an event I recognize,: ignoring"
         debug_message payload_type(payload)

--- a/lib/thumbs/pull_request_worker.rb
+++ b/lib/thumbs/pull_request_worker.rb
@@ -572,9 +572,9 @@ module Thumbs
 
     def create_build_status_comment
       if aggregate_build_status_result == :ok
-        @status_title="Looks good!  :+1:"
+        @status_title="\n> Looks good!  :+1: |"
       else
-        @status_title="Looks like there's an issue with build step #{build_status_problem_steps.join(",")} !  :cloud: "
+        @status_title="\n> There seems to be an issue with build step **#{build_status_problem_steps.join(",")}** !  :cloud: "
       end
 
       build_comment = render_template <<-EOS

--- a/lib/thumbs/pull_request_worker.rb
+++ b/lib/thumbs/pull_request_worker.rb
@@ -572,7 +572,7 @@ module Thumbs
 
     def create_build_status_comment
       if aggregate_build_status_result == :ok
-        @status_title="\n<details><Summary>**Looks good!**  :+1: </Summary>"
+        @status_title="\n<details><Summary>Looks good!  :+1: </Summary>"
       else
         @status_title="\n<details><Summary>There seems to be an issue with build step **#{build_status_problem_steps.join(",")}** !  :cloud: </Summary>"
       end

--- a/lib/thumbs/pull_request_worker.rb
+++ b/lib/thumbs/pull_request_worker.rb
@@ -75,25 +75,26 @@ module Thumbs
         git.checkout(most_recent_head_sha)
         git.checkout(@pr.base.ref)
         git.branch(pr_branch).checkout
-        debug_message "Trying merge #{@repo}:PR##{@pr.number} \" #{@pr.title}\" #{most_recent_head_sha} onto #{@pr.base.ref}"
+        debug_message "Trying merge #{@repo}:PR##{@pr.number} \" #{@pr.title}\" #{most_recent_head_sha} onto #{@pr.base.ref} #{most_recent_base_sha}"
         merge_result = git.merge("#{most_recent_head_sha}")
         load_thumbs_config
         status[:ended_at]=DateTime.now
         status[:result]=:ok
-        status[:message]="Merge Success: #{most_recent_head_sha} onto target branch: #{@pr.base.ref}"
+        status[:message]="Merge Success: #{@pr.head.ref} #{most_recent_head_sha} onto target branch: #{@pr.base.ref} #{most_recent_base_sha}"
         status[:output]=merge_result
       rescue => e
-        debug_message "Merge Failed"
+        debug_message "Merge Failed: #{@pr.head.ref} #{most_recent_head_sha} onto target branch: #{@pr.base.ref} #{most_recent_base_sha}"
         debug_message "PR ##{@pr[:number]} END"
 
         status[:result]=:error
-        status[:message]="Merge test failed"
+        status[:message]="Merge Failed: #{@pr.head.ref} #{most_recent_head_sha} onto target branch: #{@pr.base.ref} #{most_recent_base_sha}"
         status[:output]=e.inspect
       end
 
       @build_status[:steps][:merge]=status
       status
     end
+
 
     def try_run_build_step(name, command)
       status={}

--- a/lib/thumbs/pull_request_worker.rb
+++ b/lib/thumbs/pull_request_worker.rb
@@ -572,9 +572,9 @@ module Thumbs
 
     def create_build_status_comment
       if aggregate_build_status_result == :ok
-        @status_title="\n> Looks good!  :+1: |"
+        @status_title="\n<details><Summary>**Looks good!**  :+1: </Summary>"
       else
-        @status_title="\n> There seems to be an issue with build step **#{build_status_problem_steps.join(",")}** !  :cloud: "
+        @status_title="\n<details><Summary>There seems to be an issue with build step **#{build_status_problem_steps.join(",")}** !  :cloud: </Summary>"
       end
 
       build_comment = render_template <<-EOS
@@ -612,6 +612,8 @@ module Thumbs
 
 <% end %>
 <%= render_reviewers_comment_template %>
+
+</details>
       EOS
       comment_id = get_build_progress_comment[:id]
       comment_message = compose_build_status_comment_title(:completed)

--- a/lib/thumbs/pull_request_worker.rb
+++ b/lib/thumbs/pull_request_worker.rb
@@ -300,7 +300,7 @@ module Thumbs
     end
 
     def build_guid
-      "#{repo.split(/\//).pop}:#{pr.base.ref}:#{pr.base.sha.slice(0,7)}:#{pr.head.ref}:#{most_recent_sha.slice(0,7)}"
+      "#{pr.base.ref}:#{pr.base.sha.slice(0,7)}:#{pr.head.ref}:#{most_recent_sha.slice(0,7)}"
     end
     def set_build_progress(progress_status)
       update_or_create_build_status(most_recent_sha, progress_status)

--- a/lib/thumbs/pull_request_worker.rb
+++ b/lib/thumbs/pull_request_worker.rb
@@ -284,13 +284,13 @@ module Thumbs
       debug_message "got build_progress_comment #{build_progress_comment}"
       return :unstarted unless build_progress_comment
       return :unstarted unless build_progress_comment.kind_of?(Hash) && build_progress_comment.key?(:body)
-
-      progress_status_line = build_progress_comment[:body].split(/\n/).shift
       return :unstarted unless build_progress_comment[:body].length > 0
-      progress_status = progress_status_line.split(/:/).pop
+
+      progress_status_line = build_progress_comment[:body].lines[2]
+      progress_status = progress_status_line.split(/\|/).pop.split(/\s+/).pop
 
       unless progress_status
-        debug_message "go"
+        debug_message "invalid"
         return :unstarted
       end
 
@@ -306,8 +306,12 @@ module Thumbs
       update_or_create_build_status(most_recent_sha, progress_status)
     end
 
-    def compose_build_status_comment_title(status)
-      "[ #{build_guid.gsub(/:/,' ')}] Build Status: #{ status }"
+    def compose_build_status_comment_title(progress_status)
+      status_emoji=(progress_status==:completed ? result_image(aggregate_build_status_result) : result_image(progress_status))
+      comment_title="|||||\n"
+      comment_title<<"------------ | -------------|------------ | ------------- | -------------\n"
+      comment_title<<"#{pr.head.ref} #{most_recent_sha.slice(0,7)} | :arrow_right: | #{pr.base.ref} #{pr.base.sha.slice(0,7)} | #{status_emoji} #{progress_status}"
+      comment_title
     end
 
     def set_build_status_comment(sha, status)
@@ -316,6 +320,15 @@ module Thumbs
       unless comment.key?(:id)
         add_comment(compose_build_status_comment_title(status))
       end
+    end
+
+    def get_build_progress_comment
+      bot_comments.collect do |c|
+        next unless c[:body].lines.length > 1
+        status_line = c[:body].lines[2]
+        next unless status_line =~ /^#{pr.head.ref} #{most_recent_sha.slice(0,7)} \| :arrow_right: \| #{pr.base.ref} #{pr.base.sha.slice(0,7)}/
+        c
+      end.compact[0] || {:body => ""}
     end
 
     def comments_after_sha(sha)
@@ -361,9 +374,7 @@ module Thumbs
       build_progress_comment ? client.delete_comment(repo, build_progress_comment[:id]) : true
     end
 
-    def get_build_progress_comment
-      bot_comments.collect { |c| c if c[:body] =~ /^\[ #{build_guid.gsub(/:/, ' ')}/ }.compact[0] || {:body => ""}
-    end
+
 
     def pushes
       events.collect { |e| e if e[:type] == 'PushEvent' }.compact
@@ -561,9 +572,9 @@ module Thumbs
 
     def create_build_status_comment
       if aggregate_build_status_result == :ok
-        @status_title="Looks good!  :+1:"
+        @status_title="\n<details><Summary>**Looks good!**  :+1: </Summary>"
       else
-        @status_title="Looks like there's an issue with build step #{build_status_problem_steps.join(",")} !  :cloud: "
+        @status_title="\n<details><Summary>There seems to be an issue with build step **#{build_status_problem_steps.join(",")}** !  :cloud: </Summary>"
       end
 
       build_comment = render_template <<-EOS
@@ -601,6 +612,8 @@ module Thumbs
 
 <% end %>
 <%= render_reviewers_comment_template %>
+
+</details>
       EOS
       comment_id = get_build_progress_comment[:id]
       comment_message = compose_build_status_comment_title(:completed)
@@ -662,6 +675,8 @@ module Thumbs
 
     def result_image(result)
       case result
+        when :in_progress
+           ":clock1:"
         when :ok
           ":white_check_mark:"
         when :warning

--- a/lib/thumbs/webhook_helpers.rb
+++ b/lib/thumbs/webhook_helpers.rb
@@ -7,27 +7,30 @@ module Sinatra
       return :new_pr if payload['action']=='opened' && payload.key?('pull_request') && payload['pull_request'].key?('number')
       return :new_comment if payload.key?('comment') && payload.key?('issue') && payload['comment'].key?('body')
       return :new_push if payload['action']=='synchronize'
-      # return :new_base if payload['action']=='edited' &&
-      #     payload.key?('changes') &&
-      #     payload['changes'].key?('base') &&
-      #     payload['changes']['base'].key?('ref') &&
-      #     payload['changes']['base']['ref'].key?('from')
-      # merged_base_keys=%w[ref before after commits head_commit pusher repository]
-      # return :unregistered unless payload.key?('ref') && payload['ref'].length > 1
-      # return :merged_base if (merged_base_keys.collect{|key| key if payload.key?(key) }.compact.length == merged_base_keys.length)
+      return :new_base if payload['action']=='edited' &&
+          payload.key?('changes') &&
+          payload['changes'].key?('base') &&
+          payload['changes']['base'].key?('ref') &&
+          payload['changes']['base']['ref'].key?('from')
+      merged_base_keys=%w[ref before after commits head_commit pusher repository]
+
+      if payload.key?('ref') && payload['ref'].length > 1
+        matched_keys=merged_base_keys.collect{|key| key if payload.key?(key) }.compact
+        return :merged_base if (matched_keys.length == merged_base_keys.length)
+      end
       :unregistered
     end
 
     def process_payload(payload)
       case payload_type(payload)
-        # when :merged_base
-        #   debug_message "merged_base payload"
-        #   print payload.to_yaml
-        #   print "payload"
-        #   base=payload['ref'].split('/').pop
-        #   [payload['repository']['full_name'], base]
-        # when :new_base
-        #   [payload['repository']['full_name'], payload['pull_request']['number']]
+        when :merged_base
+          debug_message "merged_base payload"
+          print payload.to_yaml
+          print "payload"
+          base=payload['ref'].split('/').pop
+          [payload['repository']['full_name'], base]
+        when :new_base
+          [payload['repository']['full_name'], payload['pull_request']['number']]
         when :new_push
           [payload['repository']['full_name'], payload['pull_request']['number']]
         when :new_pr

--- a/lib/thumbs/webhook_helpers.rb
+++ b/lib/thumbs/webhook_helpers.rb
@@ -7,11 +7,18 @@ module Sinatra
       return :new_pr if payload['action']=='opened' && payload.key?('pull_request') && payload['pull_request'].key?('number')
       return :new_comment if payload.key?('comment') && payload.key?('issue') && payload['comment'].key?('body')
       return :new_push if payload['action']=='synchronize'
+      return :new_base if payload['action']=='edited' &&
+          payload.key?('changes') &&
+          payload['changes'].key?('base') &&
+          payload['changes']['base'].key?('ref') &&
+          payload['changes']['base']['ref'].key?('from')
       :unregistered
     end
 
     def process_payload(payload)
       case payload_type(payload)
+        when :new_base
+          [payload['repository']['full_name'], payload['pull_request']['number']]
         when :new_push
           [payload['repository']['full_name'], payload['pull_request']['number']]
         when :new_pr

--- a/lib/thumbs/webhook_helpers.rb
+++ b/lib/thumbs/webhook_helpers.rb
@@ -7,18 +7,27 @@ module Sinatra
       return :new_pr if payload['action']=='opened' && payload.key?('pull_request') && payload['pull_request'].key?('number')
       return :new_comment if payload.key?('comment') && payload.key?('issue') && payload['comment'].key?('body')
       return :new_push if payload['action']=='synchronize'
-      return :new_base if payload['action']=='edited' &&
-          payload.key?('changes') &&
-          payload['changes'].key?('base') &&
-          payload['changes']['base'].key?('ref') &&
-          payload['changes']['base']['ref'].key?('from')
+      # return :new_base if payload['action']=='edited' &&
+      #     payload.key?('changes') &&
+      #     payload['changes'].key?('base') &&
+      #     payload['changes']['base'].key?('ref') &&
+      #     payload['changes']['base']['ref'].key?('from')
+      # merged_base_keys=%w[ref before after commits head_commit pusher repository]
+      # return :unregistered unless payload.key?('ref') && payload['ref'].length > 1
+      # return :merged_base if (merged_base_keys.collect{|key| key if payload.key?(key) }.compact.length == merged_base_keys.length)
       :unregistered
     end
 
     def process_payload(payload)
       case payload_type(payload)
-        when :new_base
-          [payload['repository']['full_name'], payload['pull_request']['number']]
+        # when :merged_base
+        #   debug_message "merged_base payload"
+        #   print payload.to_yaml
+        #   print "payload"
+        #   base=payload['ref'].split('/').pop
+        #   [payload['repository']['full_name'], base]
+        # when :new_base
+        #   [payload['repository']['full_name'], payload['pull_request']['number']]
         when :new_push
           [payload['repository']['full_name'], payload['pull_request']['number']]
         when :new_pr

--- a/test/fixtures/edit_pr.yml
+++ b/test/fixtures/edit_pr.yml
@@ -1,0 +1,398 @@
+action: edited
+number: 252
+pull_request:
+  url: https://api.github.com/repos/davidx/prtester/pulls/252
+  id: 90691454
+  html_url: https://github.com/davidx/prtester/pull/252
+  diff_url: https://github.com/davidx/prtester/pull/252.diff
+  patch_url: https://github.com/davidx/prtester/pull/252.patch
+  issue_url: https://api.github.com/repos/davidx/prtester/issues/252
+  number: 252
+  state: open
+  locked: false
+  title: whaat
+  user:
+    login: davidx
+    id: 17162
+    avatar_url: https://avatars.githubusercontent.com/u/17162?v=3
+    gravatar_id: ''
+    url: https://api.github.com/users/davidx
+    html_url: https://github.com/davidx
+    followers_url: https://api.github.com/users/davidx/followers
+    following_url: https://api.github.com/users/davidx/following{/other_user}
+    gists_url: https://api.github.com/users/davidx/gists{/gist_id}
+    starred_url: https://api.github.com/users/davidx/starred{/owner}{/repo}
+    subscriptions_url: https://api.github.com/users/davidx/subscriptions
+    organizations_url: https://api.github.com/users/davidx/orgs
+    repos_url: https://api.github.com/users/davidx/repos
+    events_url: https://api.github.com/users/davidx/events{/privacy}
+    received_events_url: https://api.github.com/users/davidx/received_events
+    type: User
+    site_admin: false
+  body: ''
+  created_at: '2016-10-24T20:58:24Z'
+  updated_at: '2016-10-24T21:12:48Z'
+  closed_at:
+  merged_at:
+  merge_commit_sha: 364e7b541c895bc53faa671054e4a66915bb1a82
+  assignee:
+  assignees: []
+  milestone:
+  commits_url: https://api.github.com/repos/davidx/prtester/pulls/252/commits
+  review_comments_url: https://api.github.com/repos/davidx/prtester/pulls/252/comments
+  review_comment_url: https://api.github.com/repos/davidx/prtester/pulls/comments{/number}
+  comments_url: https://api.github.com/repos/davidx/prtester/issues/252/comments
+  statuses_url: https://api.github.com/repos/davidx/prtester/statuses/eec6cb8debc99a877938517527c232d607bed39b
+  head:
+    label: davidx:1477342513
+    ref: '1477342513'
+    sha: eec6cb8debc99a877938517527c232d607bed39b
+    user:
+      login: davidx
+      id: 17162
+      avatar_url: https://avatars.githubusercontent.com/u/17162?v=3
+      gravatar_id: ''
+      url: https://api.github.com/users/davidx
+      html_url: https://github.com/davidx
+      followers_url: https://api.github.com/users/davidx/followers
+      following_url: https://api.github.com/users/davidx/following{/other_user}
+      gists_url: https://api.github.com/users/davidx/gists{/gist_id}
+      starred_url: https://api.github.com/users/davidx/starred{/owner}{/repo}
+      subscriptions_url: https://api.github.com/users/davidx/subscriptions
+      organizations_url: https://api.github.com/users/davidx/orgs
+      repos_url: https://api.github.com/users/davidx/repos
+      events_url: https://api.github.com/users/davidx/events{/privacy}
+      received_events_url: https://api.github.com/users/davidx/received_events
+      type: User
+      site_admin: false
+    repo:
+      id: 64998050
+      name: prtester
+      full_name: davidx/prtester
+      owner:
+        login: davidx
+        id: 17162
+        avatar_url: https://avatars.githubusercontent.com/u/17162?v=3
+        gravatar_id: ''
+        url: https://api.github.com/users/davidx
+        html_url: https://github.com/davidx
+        followers_url: https://api.github.com/users/davidx/followers
+        following_url: https://api.github.com/users/davidx/following{/other_user}
+        gists_url: https://api.github.com/users/davidx/gists{/gist_id}
+        starred_url: https://api.github.com/users/davidx/starred{/owner}{/repo}
+        subscriptions_url: https://api.github.com/users/davidx/subscriptions
+        organizations_url: https://api.github.com/users/davidx/orgs
+        repos_url: https://api.github.com/users/davidx/repos
+        events_url: https://api.github.com/users/davidx/events{/privacy}
+        received_events_url: https://api.github.com/users/davidx/received_events
+        type: User
+        site_admin: false
+      private: false
+      html_url: https://github.com/davidx/prtester
+      description: testing pr
+      fork: false
+      url: https://api.github.com/repos/davidx/prtester
+      forks_url: https://api.github.com/repos/davidx/prtester/forks
+      keys_url: https://api.github.com/repos/davidx/prtester/keys{/key_id}
+      collaborators_url: https://api.github.com/repos/davidx/prtester/collaborators{/collaborator}
+      teams_url: https://api.github.com/repos/davidx/prtester/teams
+      hooks_url: https://api.github.com/repos/davidx/prtester/hooks
+      issue_events_url: https://api.github.com/repos/davidx/prtester/issues/events{/number}
+      events_url: https://api.github.com/repos/davidx/prtester/events
+      assignees_url: https://api.github.com/repos/davidx/prtester/assignees{/user}
+      branches_url: https://api.github.com/repos/davidx/prtester/branches{/branch}
+      tags_url: https://api.github.com/repos/davidx/prtester/tags
+      blobs_url: https://api.github.com/repos/davidx/prtester/git/blobs{/sha}
+      git_tags_url: https://api.github.com/repos/davidx/prtester/git/tags{/sha}
+      git_refs_url: https://api.github.com/repos/davidx/prtester/git/refs{/sha}
+      trees_url: https://api.github.com/repos/davidx/prtester/git/trees{/sha}
+      statuses_url: https://api.github.com/repos/davidx/prtester/statuses/{sha}
+      languages_url: https://api.github.com/repos/davidx/prtester/languages
+      stargazers_url: https://api.github.com/repos/davidx/prtester/stargazers
+      contributors_url: https://api.github.com/repos/davidx/prtester/contributors
+      subscribers_url: https://api.github.com/repos/davidx/prtester/subscribers
+      subscription_url: https://api.github.com/repos/davidx/prtester/subscription
+      commits_url: https://api.github.com/repos/davidx/prtester/commits{/sha}
+      git_commits_url: https://api.github.com/repos/davidx/prtester/git/commits{/sha}
+      comments_url: https://api.github.com/repos/davidx/prtester/comments{/number}
+      issue_comment_url: https://api.github.com/repos/davidx/prtester/issues/comments{/number}
+      contents_url: https://api.github.com/repos/davidx/prtester/contents/{+path}
+      compare_url: https://api.github.com/repos/davidx/prtester/compare/{base}...{head}
+      merges_url: https://api.github.com/repos/davidx/prtester/merges
+      archive_url: https://api.github.com/repos/davidx/prtester/{archive_format}{/ref}
+      downloads_url: https://api.github.com/repos/davidx/prtester/downloads
+      issues_url: https://api.github.com/repos/davidx/prtester/issues{/number}
+      pulls_url: https://api.github.com/repos/davidx/prtester/pulls{/number}
+      milestones_url: https://api.github.com/repos/davidx/prtester/milestones{/number}
+      notifications_url: https://api.github.com/repos/davidx/prtester/notifications{?since,all,participating}
+      labels_url: https://api.github.com/repos/davidx/prtester/labels{/name}
+      releases_url: https://api.github.com/repos/davidx/prtester/releases{/id}
+      deployments_url: https://api.github.com/repos/davidx/prtester/deployments
+      created_at: '2016-08-05T07:21:52Z'
+      updated_at: '2016-08-05T07:29:52Z'
+      pushed_at: '2016-10-24T21:09:01Z'
+      git_url: git://github.com/davidx/prtester.git
+      ssh_url: git@github.com:davidx/prtester.git
+      clone_url: https://github.com/davidx/prtester.git
+      svn_url: https://github.com/davidx/prtester
+      homepage:
+      size: 216
+      stargazers_count: 0
+      watchers_count: 0
+      language: Makefile
+      has_issues: true
+      has_downloads: true
+      has_wiki: true
+      has_pages: false
+      forks_count: 2
+      mirror_url:
+      open_issues_count: 9
+      forks: 2
+      open_issues: 9
+      watchers: 0
+      default_branch: master
+  base:
+    label: davidx:1473975779
+    ref: '1473975779'
+    sha: 22b8e6034d603fa6ed700487c5ed20886ebfe5ef
+    user:
+      login: davidx
+      id: 17162
+      avatar_url: https://avatars.githubusercontent.com/u/17162?v=3
+      gravatar_id: ''
+      url: https://api.github.com/users/davidx
+      html_url: https://github.com/davidx
+      followers_url: https://api.github.com/users/davidx/followers
+      following_url: https://api.github.com/users/davidx/following{/other_user}
+      gists_url: https://api.github.com/users/davidx/gists{/gist_id}
+      starred_url: https://api.github.com/users/davidx/starred{/owner}{/repo}
+      subscriptions_url: https://api.github.com/users/davidx/subscriptions
+      organizations_url: https://api.github.com/users/davidx/orgs
+      repos_url: https://api.github.com/users/davidx/repos
+      events_url: https://api.github.com/users/davidx/events{/privacy}
+      received_events_url: https://api.github.com/users/davidx/received_events
+      type: User
+      site_admin: false
+    repo:
+      id: 64998050
+      name: prtester
+      full_name: davidx/prtester
+      owner:
+        login: davidx
+        id: 17162
+        avatar_url: https://avatars.githubusercontent.com/u/17162?v=3
+        gravatar_id: ''
+        url: https://api.github.com/users/davidx
+        html_url: https://github.com/davidx
+        followers_url: https://api.github.com/users/davidx/followers
+        following_url: https://api.github.com/users/davidx/following{/other_user}
+        gists_url: https://api.github.com/users/davidx/gists{/gist_id}
+        starred_url: https://api.github.com/users/davidx/starred{/owner}{/repo}
+        subscriptions_url: https://api.github.com/users/davidx/subscriptions
+        organizations_url: https://api.github.com/users/davidx/orgs
+        repos_url: https://api.github.com/users/davidx/repos
+        events_url: https://api.github.com/users/davidx/events{/privacy}
+        received_events_url: https://api.github.com/users/davidx/received_events
+        type: User
+        site_admin: false
+      private: false
+      html_url: https://github.com/davidx/prtester
+      description: testing pr
+      fork: false
+      url: https://api.github.com/repos/davidx/prtester
+      forks_url: https://api.github.com/repos/davidx/prtester/forks
+      keys_url: https://api.github.com/repos/davidx/prtester/keys{/key_id}
+      collaborators_url: https://api.github.com/repos/davidx/prtester/collaborators{/collaborator}
+      teams_url: https://api.github.com/repos/davidx/prtester/teams
+      hooks_url: https://api.github.com/repos/davidx/prtester/hooks
+      issue_events_url: https://api.github.com/repos/davidx/prtester/issues/events{/number}
+      events_url: https://api.github.com/repos/davidx/prtester/events
+      assignees_url: https://api.github.com/repos/davidx/prtester/assignees{/user}
+      branches_url: https://api.github.com/repos/davidx/prtester/branches{/branch}
+      tags_url: https://api.github.com/repos/davidx/prtester/tags
+      blobs_url: https://api.github.com/repos/davidx/prtester/git/blobs{/sha}
+      git_tags_url: https://api.github.com/repos/davidx/prtester/git/tags{/sha}
+      git_refs_url: https://api.github.com/repos/davidx/prtester/git/refs{/sha}
+      trees_url: https://api.github.com/repos/davidx/prtester/git/trees{/sha}
+      statuses_url: https://api.github.com/repos/davidx/prtester/statuses/{sha}
+      languages_url: https://api.github.com/repos/davidx/prtester/languages
+      stargazers_url: https://api.github.com/repos/davidx/prtester/stargazers
+      contributors_url: https://api.github.com/repos/davidx/prtester/contributors
+      subscribers_url: https://api.github.com/repos/davidx/prtester/subscribers
+      subscription_url: https://api.github.com/repos/davidx/prtester/subscription
+      commits_url: https://api.github.com/repos/davidx/prtester/commits{/sha}
+      git_commits_url: https://api.github.com/repos/davidx/prtester/git/commits{/sha}
+      comments_url: https://api.github.com/repos/davidx/prtester/comments{/number}
+      issue_comment_url: https://api.github.com/repos/davidx/prtester/issues/comments{/number}
+      contents_url: https://api.github.com/repos/davidx/prtester/contents/{+path}
+      compare_url: https://api.github.com/repos/davidx/prtester/compare/{base}...{head}
+      merges_url: https://api.github.com/repos/davidx/prtester/merges
+      archive_url: https://api.github.com/repos/davidx/prtester/{archive_format}{/ref}
+      downloads_url: https://api.github.com/repos/davidx/prtester/downloads
+      issues_url: https://api.github.com/repos/davidx/prtester/issues{/number}
+      pulls_url: https://api.github.com/repos/davidx/prtester/pulls{/number}
+      milestones_url: https://api.github.com/repos/davidx/prtester/milestones{/number}
+      notifications_url: https://api.github.com/repos/davidx/prtester/notifications{?since,all,participating}
+      labels_url: https://api.github.com/repos/davidx/prtester/labels{/name}
+      releases_url: https://api.github.com/repos/davidx/prtester/releases{/id}
+      deployments_url: https://api.github.com/repos/davidx/prtester/deployments
+      created_at: '2016-08-05T07:21:52Z'
+      updated_at: '2016-08-05T07:29:52Z'
+      pushed_at: '2016-10-24T21:09:01Z'
+      git_url: git://github.com/davidx/prtester.git
+      ssh_url: git@github.com:davidx/prtester.git
+      clone_url: https://github.com/davidx/prtester.git
+      svn_url: https://github.com/davidx/prtester
+      homepage:
+      size: 216
+      stargazers_count: 0
+      watchers_count: 0
+      language: Makefile
+      has_issues: true
+      has_downloads: true
+      has_wiki: true
+      has_pages: false
+      forks_count: 2
+      mirror_url:
+      open_issues_count: 9
+      forks: 2
+      open_issues: 9
+      watchers: 0
+      default_branch: master
+  _links:
+    self:
+      href: https://api.github.com/repos/davidx/prtester/pulls/252
+    html:
+      href: https://github.com/davidx/prtester/pull/252
+    issue:
+      href: https://api.github.com/repos/davidx/prtester/issues/252
+    comments:
+      href: https://api.github.com/repos/davidx/prtester/issues/252/comments
+    review_comments:
+      href: https://api.github.com/repos/davidx/prtester/pulls/252/comments
+    review_comment:
+      href: https://api.github.com/repos/davidx/prtester/pulls/comments{/number}
+    commits:
+      href: https://api.github.com/repos/davidx/prtester/pulls/252/commits
+    statuses:
+      href: https://api.github.com/repos/davidx/prtester/statuses/eec6cb8debc99a877938517527c232d607bed39b
+  merged: false
+  mergeable:
+  mergeable_state: unknown
+  merged_by:
+  comments: 3
+  review_comments: 0
+  commits: 72
+  additions: 15
+  deletions: 6
+  changed_files: 3
+changes:
+  base:
+    ref:
+      from: master
+    sha:
+      from: afadb0afefe87362ca819a4a78b5bc89dede3133
+repository:
+  id: 64998050
+  name: prtester
+  full_name: davidx/prtester
+  owner:
+    login: davidx
+    id: 17162
+    avatar_url: https://avatars.githubusercontent.com/u/17162?v=3
+    gravatar_id: ''
+    url: https://api.github.com/users/davidx
+    html_url: https://github.com/davidx
+    followers_url: https://api.github.com/users/davidx/followers
+    following_url: https://api.github.com/users/davidx/following{/other_user}
+    gists_url: https://api.github.com/users/davidx/gists{/gist_id}
+    starred_url: https://api.github.com/users/davidx/starred{/owner}{/repo}
+    subscriptions_url: https://api.github.com/users/davidx/subscriptions
+    organizations_url: https://api.github.com/users/davidx/orgs
+    repos_url: https://api.github.com/users/davidx/repos
+    events_url: https://api.github.com/users/davidx/events{/privacy}
+    received_events_url: https://api.github.com/users/davidx/received_events
+    type: User
+    site_admin: false
+  private: false
+  html_url: https://github.com/davidx/prtester
+  description: testing pr
+  fork: false
+  url: https://api.github.com/repos/davidx/prtester
+  forks_url: https://api.github.com/repos/davidx/prtester/forks
+  keys_url: https://api.github.com/repos/davidx/prtester/keys{/key_id}
+  collaborators_url: https://api.github.com/repos/davidx/prtester/collaborators{/collaborator}
+  teams_url: https://api.github.com/repos/davidx/prtester/teams
+  hooks_url: https://api.github.com/repos/davidx/prtester/hooks
+  issue_events_url: https://api.github.com/repos/davidx/prtester/issues/events{/number}
+  events_url: https://api.github.com/repos/davidx/prtester/events
+  assignees_url: https://api.github.com/repos/davidx/prtester/assignees{/user}
+  branches_url: https://api.github.com/repos/davidx/prtester/branches{/branch}
+  tags_url: https://api.github.com/repos/davidx/prtester/tags
+  blobs_url: https://api.github.com/repos/davidx/prtester/git/blobs{/sha}
+  git_tags_url: https://api.github.com/repos/davidx/prtester/git/tags{/sha}
+  git_refs_url: https://api.github.com/repos/davidx/prtester/git/refs{/sha}
+  trees_url: https://api.github.com/repos/davidx/prtester/git/trees{/sha}
+  statuses_url: https://api.github.com/repos/davidx/prtester/statuses/{sha}
+  languages_url: https://api.github.com/repos/davidx/prtester/languages
+  stargazers_url: https://api.github.com/repos/davidx/prtester/stargazers
+  contributors_url: https://api.github.com/repos/davidx/prtester/contributors
+  subscribers_url: https://api.github.com/repos/davidx/prtester/subscribers
+  subscription_url: https://api.github.com/repos/davidx/prtester/subscription
+  commits_url: https://api.github.com/repos/davidx/prtester/commits{/sha}
+  git_commits_url: https://api.github.com/repos/davidx/prtester/git/commits{/sha}
+  comments_url: https://api.github.com/repos/davidx/prtester/comments{/number}
+  issue_comment_url: https://api.github.com/repos/davidx/prtester/issues/comments{/number}
+  contents_url: https://api.github.com/repos/davidx/prtester/contents/{+path}
+  compare_url: https://api.github.com/repos/davidx/prtester/compare/{base}...{head}
+  merges_url: https://api.github.com/repos/davidx/prtester/merges
+  archive_url: https://api.github.com/repos/davidx/prtester/{archive_format}{/ref}
+  downloads_url: https://api.github.com/repos/davidx/prtester/downloads
+  issues_url: https://api.github.com/repos/davidx/prtester/issues{/number}
+  pulls_url: https://api.github.com/repos/davidx/prtester/pulls{/number}
+  milestones_url: https://api.github.com/repos/davidx/prtester/milestones{/number}
+  notifications_url: https://api.github.com/repos/davidx/prtester/notifications{?since,all,participating}
+  labels_url: https://api.github.com/repos/davidx/prtester/labels{/name}
+  releases_url: https://api.github.com/repos/davidx/prtester/releases{/id}
+  deployments_url: https://api.github.com/repos/davidx/prtester/deployments
+  created_at: '2016-08-05T07:21:52Z'
+  updated_at: '2016-08-05T07:29:52Z'
+  pushed_at: '2016-10-24T21:09:01Z'
+  git_url: git://github.com/davidx/prtester.git
+  ssh_url: git@github.com:davidx/prtester.git
+  clone_url: https://github.com/davidx/prtester.git
+  svn_url: https://github.com/davidx/prtester
+  homepage:
+  size: 216
+  stargazers_count: 0
+  watchers_count: 0
+  language: Makefile
+  has_issues: true
+  has_downloads: true
+  has_wiki: true
+  has_pages: false
+  forks_count: 2
+  mirror_url:
+  open_issues_count: 9
+  forks: 2
+  open_issues: 9
+  watchers: 0
+  default_branch: master
+sender:
+  login: davidx
+  id: 17162
+  avatar_url: https://avatars.githubusercontent.com/u/17162?v=3
+  gravatar_id: ''
+  url: https://api.github.com/users/davidx
+  html_url: https://github.com/davidx
+  followers_url: https://api.github.com/users/davidx/followers
+  following_url: https://api.github.com/users/davidx/following{/other_user}
+  gists_url: https://api.github.com/users/davidx/gists{/gist_id}
+  starred_url: https://api.github.com/users/davidx/starred{/owner}{/repo}
+  subscriptions_url: https://api.github.com/users/davidx/subscriptions
+  organizations_url: https://api.github.com/users/davidx/orgs
+  repos_url: https://api.github.com/users/davidx/repos
+  events_url: https://api.github.com/users/davidx/events{/privacy}
+  received_events_url: https://api.github.com/users/davidx/received_events
+  type: User
+  site_admin: false

--- a/test/fixtures/merge_pr.yml
+++ b/test/fixtures/merge_pr.yml
@@ -1,0 +1,185 @@
+---
+ref: refs/heads/master
+before: e65bc8ef21630b917ca9ecc62adb3b17c1cbe2ef
+after: 34ae62fe74815d254b78c5b1c57979dd8b9e4de5
+created: false
+deleted: false
+forced: false
+base_ref:
+compare: https://github.com/davidx/prtester/compare/e65bc8ef2163...34ae62fe7481
+commits:
+- id: 6ef8e11b10cc93b070f9fe7bd832a969defc06b0
+  tree_id: fdd7bc647635b96320b45290f0235e62235384d9
+  distinct: false
+  message: add
+  timestamp: '2016-10-26T20:55:04-07:00'
+  url: https://github.com/davidx/prtester/commit/6ef8e11b10cc93b070f9fe7bd832a969defc06b0
+  author:
+    name: David Andersen
+    email: davidx@gmail.com
+    username: davidx
+  committer:
+    name: David Andersen
+    email: davidx@gmail.com
+    username: davidx
+  added:
+  - testfile2
+  removed: []
+  modified: []
+- id: ac852eb7b23ac76f91d0836bbd3146da19411a52
+  tree_id: 8b3d3e88365610d4d4ec7bb4af4e108925aef026
+  distinct: false
+  message: test
+  timestamp: '2016-10-27T09:20:48-07:00'
+  url: https://github.com/davidx/prtester/commit/ac852eb7b23ac76f91d0836bbd3146da19411a52
+  author:
+    name: David Andersen
+    email: davidx@gmail.com
+    username: davidx
+  committer:
+    name: David Andersen
+    email: davidx@gmail.com
+    username: davidx
+  added: []
+  removed: []
+  modified:
+  - ".thumbs.yml"
+- id: 34ae62fe74815d254b78c5b1c57979dd8b9e4de5
+  tree_id: 3b3185022c9089b4e5613183970fd8bf86dd247d
+  distinct: true
+  message: |-
+    Merge pull request #268 from davidx/mergable_diff
+
+    Thumbs Git Robot Merge.
+  timestamp: '2016-10-27T09:21:56-07:00'
+  url: https://github.com/davidx/prtester/commit/34ae62fe74815d254b78c5b1c57979dd8b9e4de5
+  author:
+    name: Thumbs
+    email: git.thumbs@gmail.com
+    username: thumbot
+  committer:
+    name: GitHub
+    email: noreply@github.com
+    username: web-flow
+  added:
+  - testfile2
+  removed: []
+  modified:
+  - ".thumbs.yml"
+head_commit:
+  id: 34ae62fe74815d254b78c5b1c57979dd8b9e4de5
+  tree_id: 3b3185022c9089b4e5613183970fd8bf86dd247d
+  distinct: true
+  message: |-
+    Merge pull request #268 from davidx/mergable_diff
+
+    Thumbs Git Robot Merge.
+  timestamp: '2016-10-27T09:21:56-07:00'
+  url: https://github.com/davidx/prtester/commit/34ae62fe74815d254b78c5b1c57979dd8b9e4de5
+  author:
+    name: Thumbs
+    email: git.thumbs@gmail.com
+    username: thumbot
+  committer:
+    name: GitHub
+    email: noreply@github.com
+    username: web-flow
+  added:
+  - testfile2
+  removed: []
+  modified:
+  - ".thumbs.yml"
+repository:
+  id: 64998050
+  name: prtester
+  full_name: davidx/prtester
+  owner:
+    name: davidx
+    email: davidx@gmail.com
+  private: false
+  html_url: https://github.com/davidx/prtester
+  description: testing pr
+  fork: false
+  url: https://github.com/davidx/prtester
+  forks_url: https://api.github.com/repos/davidx/prtester/forks
+  keys_url: https://api.github.com/repos/davidx/prtester/keys{/key_id}
+  collaborators_url: https://api.github.com/repos/davidx/prtester/collaborators{/collaborator}
+  teams_url: https://api.github.com/repos/davidx/prtester/teams
+  hooks_url: https://api.github.com/repos/davidx/prtester/hooks
+  issue_events_url: https://api.github.com/repos/davidx/prtester/issues/events{/number}
+  events_url: https://api.github.com/repos/davidx/prtester/events
+  assignees_url: https://api.github.com/repos/davidx/prtester/assignees{/user}
+  branches_url: https://api.github.com/repos/davidx/prtester/branches{/branch}
+  tags_url: https://api.github.com/repos/davidx/prtester/tags
+  blobs_url: https://api.github.com/repos/davidx/prtester/git/blobs{/sha}
+  git_tags_url: https://api.github.com/repos/davidx/prtester/git/tags{/sha}
+  git_refs_url: https://api.github.com/repos/davidx/prtester/git/refs{/sha}
+  trees_url: https://api.github.com/repos/davidx/prtester/git/trees{/sha}
+  statuses_url: https://api.github.com/repos/davidx/prtester/statuses/{sha}
+  languages_url: https://api.github.com/repos/davidx/prtester/languages
+  stargazers_url: https://api.github.com/repos/davidx/prtester/stargazers
+  contributors_url: https://api.github.com/repos/davidx/prtester/contributors
+  subscribers_url: https://api.github.com/repos/davidx/prtester/subscribers
+  subscription_url: https://api.github.com/repos/davidx/prtester/subscription
+  commits_url: https://api.github.com/repos/davidx/prtester/commits{/sha}
+  git_commits_url: https://api.github.com/repos/davidx/prtester/git/commits{/sha}
+  comments_url: https://api.github.com/repos/davidx/prtester/comments{/number}
+  issue_comment_url: https://api.github.com/repos/davidx/prtester/issues/comments{/number}
+  contents_url: https://api.github.com/repos/davidx/prtester/contents/{+path}
+  compare_url: https://api.github.com/repos/davidx/prtester/compare/{base}...{head}
+  merges_url: https://api.github.com/repos/davidx/prtester/merges
+  archive_url: https://api.github.com/repos/davidx/prtester/{archive_format}{/ref}
+  downloads_url: https://api.github.com/repos/davidx/prtester/downloads
+  issues_url: https://api.github.com/repos/davidx/prtester/issues{/number}
+  pulls_url: https://api.github.com/repos/davidx/prtester/pulls{/number}
+  milestones_url: https://api.github.com/repos/davidx/prtester/milestones{/number}
+  notifications_url: https://api.github.com/repos/davidx/prtester/notifications{?since,all,participating}
+  labels_url: https://api.github.com/repos/davidx/prtester/labels{/name}
+  releases_url: https://api.github.com/repos/davidx/prtester/releases{/id}
+  deployments_url: https://api.github.com/repos/davidx/prtester/deployments
+  created_at: 1470381712
+  updated_at: '2016-08-05T07:29:52Z'
+  pushed_at: 1477585316
+  git_url: git://github.com/davidx/prtester.git
+  ssh_url: git@github.com:davidx/prtester.git
+  clone_url: https://github.com/davidx/prtester.git
+  svn_url: https://github.com/davidx/prtester
+  homepage:
+  size: 273
+  stargazers_count: 0
+  watchers_count: 0
+  language: Makefile
+  has_issues: true
+  has_downloads: true
+  has_wiki: true
+  has_pages: false
+  forks_count: 2
+  mirror_url:
+  open_issues_count: 6
+  forks: 2
+  open_issues: 6
+  watchers: 0
+  default_branch: master
+  stargazers: 0
+  master_branch: master
+pusher:
+  name: thumbot
+  email: git.thumbs@gmail.com
+sender:
+  login: thumbot
+  id: 20921557
+  avatar_url: https://avatars.githubusercontent.com/u/20921557?v=3
+  gravatar_id: ''
+  url: https://api.github.com/users/thumbot
+  html_url: https://github.com/thumbot
+  followers_url: https://api.github.com/users/thumbot/followers
+  following_url: https://api.github.com/users/thumbot/following{/other_user}
+  gists_url: https://api.github.com/users/thumbot/gists{/gist_id}
+  starred_url: https://api.github.com/users/thumbot/starred{/owner}{/repo}
+  subscriptions_url: https://api.github.com/users/thumbot/subscriptions
+  organizations_url: https://api.github.com/users/thumbot/orgs
+  repos_url: https://api.github.com/users/thumbot/repos
+  events_url: https://api.github.com/users/thumbot/events{/privacy}
+  received_events_url: https://api.github.com/users/thumbot/received_events
+  type: User
+  site_admin: false

--- a/test/test.rb
+++ b/test/test.rb
@@ -2,7 +2,7 @@ $:.unshift(File.dirname(__FILE__))
 $:.unshift(File.join(File.dirname(__FILE__), '/../'))
 
 ENV['RACK_ENV'] = 'test'
-
+#
 require 'test/test_helper'
 require 'test/test_webhook'
 require 'test/test_payload'

--- a/test/test.rb
+++ b/test/test.rb
@@ -9,4 +9,5 @@ require 'test/test_payload'
 require 'test/test_persisted_build_status'
 require 'test/test_build_steps'
 require 'test/test_state'
+require 'test/test_common'
 

--- a/test/test_build_steps.rb
+++ b/test/test_build_steps.rb
@@ -26,7 +26,7 @@ unit_tests do
       assert status.key?(:result)
       assert status.key?(:message)
       assert status.key?(:command)
-      assert_equal "cd /tmp/thumbs/thumbot_prtester_#{prw.pr.head.sha.slice(0, 10)} && uptime 2>&1", status[:command]
+      assert_equal "cd /tmp/thumbs/#{prw.build_guid} && uptime 2>&1", status[:command]
       assert status.key?(:output)
 
       assert status.key?(:exit_code)
@@ -71,7 +71,7 @@ unit_tests do
       assert status[:exit_code]==0
       assert status.key?(:result)
       assert status[:result]==:ok
-      build_dir_path="/tmp/thumbs/#{prw.repo.gsub(/\//, '_')}_#{prw.pr.head.sha.slice(0, 10)}"
+      build_dir_path="/tmp/thumbs/#{prw.build_guid}"
       assert_equal "cd #{build_dir_path} && make build 2>&1", status[:command]
 
       assert_equal "BUILD OK\n", status[:output]

--- a/test/test_build_steps.rb
+++ b/test/test_build_steps.rb
@@ -107,7 +107,9 @@ unit_tests do
       cassette(:comments) do
         assert prw.respond_to?(:valid_for_merge?)
         cassette(:get_state) do
-          assert_equal false, prw.valid_for_merge?
+          cassette(:get_commits) do
+            assert_equal false, prw.valid_for_merge?
+          end
         end
       end
     end
@@ -120,7 +122,9 @@ unit_tests do
       prw.try_merge
       prw.run_build_steps
       cassette(:get_state) do
-        assert_equal false, prw.valid_for_merge?
+        cassette(:get_commits) do
+          assert_equal false, prw.valid_for_merge?
+        end
       end
     end
   end

--- a/test/test_common.rb
+++ b/test/test_common.rb
@@ -6,7 +6,7 @@ unit_tests do
     default_vcr_state do
       prw = Thumbs::PullRequestWorker.new(:repo => TESTREPO, :pr => TESTPR)
       assert prw.respond_to?(:build_guid)
-      assert_equal "#{prw.pr.base.ref}:#{prw.pr.base.sha.slice(0,7)}:#{prw.pr.head.ref}:#{prw.most_recent_sha.slice(0,7)}", prw.build_guid
+      assert_equal "#{prw.pr.base.ref}:#{prw.pr.base.sha.slice(0,7)}:#{prw.pr.head.ref}:#{prw.pr.head.sha.slice(0,7)}", prw.build_guid
     end
   end
 
@@ -19,6 +19,7 @@ unit_tests do
       assert_equal open_pull_requests.collect{|pr| pr[:base][:ref] }, prw.open_pull_requests.collect{|pr| pr[:base][:ref] }
     end
   end
+
   test "can get open pull requests for repo and branch" do
     default_vcr_state do
       prw = Thumbs::PullRequestWorker.new(:repo => TESTREPO, :pr => TESTPR)
@@ -27,4 +28,33 @@ unit_tests do
       assert_equal matched_base_pull_requests.collect{|pr| pr[:base][:ref] }, prw.pull_requests_for_base_branch("master").collect{|pr| pr[:base][:ref] }
     end
   end
+
+  test "can get commits for branch " do
+    default_vcr_state do
+      prw = Thumbs::PullRequestWorker.new(:repo => TESTREPO, :pr => TESTPR)
+      commits = prw.client.commits(TESTREPO, prw.pr.head.ref)
+      assert_equal prw.commits.first[:sha], commits.first[:sha]
+    end
+  end
+
+  test "can provide most recent head sha" do
+    # do the most recent head sha from the branch
+    default_vcr_state do
+      prw = Thumbs::PullRequestWorker.new(:repo => TESTREPO, :pr => TESTPR)
+      most_recent_head_sha = prw.client.commits(prw.repo, prw.pr.head.ref).first[:sha]
+      assert_equal prw.pr.head.sha, most_recent_head_sha
+    end
+  end
+
+  test "can provide most recent base sha" do
+    # do the most recent base sha from the branch
+    default_vcr_state do
+      prw = Thumbs::PullRequestWorker.new(:repo => TESTREPO, :pr => TESTPR)
+      most_recent_base_sha = prw.client.commits(prw.repo, prw.pr.base.ref).first[:sha]
+      assert_equal prw.pr.base.sha, most_recent_base_sha
+    end
+  end
+
+  # todo show scenario where pr.base.sha  and most_recent_base_sha differ.
+
 end

--- a/test/test_common.rb
+++ b/test/test_common.rb
@@ -1,0 +1,12 @@
+
+
+unit_tests do
+
+  test "should be able to generate base and sha specific build guid" do
+    default_vcr_state do
+      prw = Thumbs::PullRequestWorker.new(:repo => TESTREPO, :pr => TESTPR)
+      assert prw.respond_to?(:build_guid)
+      assert_equal "#{prw.pr.base.ref}_#{prw.most_recent_sha.slice(0,7)}", prw.build_guid
+    end
+  end
+end

--- a/test/test_common.rb
+++ b/test/test_common.rb
@@ -6,7 +6,7 @@ unit_tests do
     default_vcr_state do
       prw = Thumbs::PullRequestWorker.new(:repo => TESTREPO, :pr => TESTPR)
       assert prw.respond_to?(:build_guid)
-      assert_equal "#{prw.repo.split(/\//).pop}:#{prw.pr.base.ref}:#{prw.pr.base.sha.slice(0,7)}:#{prw.pr.head.ref}:#{prw.most_recent_sha.slice(0,7)}", prw.build_guid
+      assert_equal "#{prw.pr.base.ref}:#{prw.pr.base.sha.slice(0,7)}:#{prw.pr.head.ref}:#{prw.most_recent_sha.slice(0,7)}", prw.build_guid
     end
   end
 

--- a/test/test_common.rb
+++ b/test/test_common.rb
@@ -6,7 +6,25 @@ unit_tests do
     default_vcr_state do
       prw = Thumbs::PullRequestWorker.new(:repo => TESTREPO, :pr => TESTPR)
       assert prw.respond_to?(:build_guid)
-      assert_equal "#{prw.pr.base.ref}_#{prw.most_recent_sha.slice(0,7)}", prw.build_guid
+      assert_equal "#{prw.repo.split(/\//).pop}:#{prw.pr.base.ref}:#{prw.pr.base.sha.slice(0,7)}:#{prw.pr.head.ref}:#{prw.most_recent_sha.slice(0,7)}", prw.build_guid
+    end
+  end
+
+
+  test "can get open pull requests for repo" do
+    default_vcr_state do
+      prw = Thumbs::PullRequestWorker.new(:repo => TESTREPO, :pr => TESTPR)
+      prw.respond_to?(:open_pull_requests)
+      open_pull_requests = prw.client.pull_requests(prw.repo, :state => 'open')
+      assert_equal open_pull_requests.collect{|pr| pr[:base][:ref] }, prw.open_pull_requests.collect{|pr| pr[:base][:ref] }
+    end
+  end
+  test "can get open pull requests for repo and branch" do
+    default_vcr_state do
+      prw = Thumbs::PullRequestWorker.new(:repo => TESTREPO, :pr => TESTPR)
+      prw.respond_to?(:pull_requests_for_base_branch)
+      matched_base_pull_requests = prw.open_pull_requests.collect{|pr| pr if pr.base.ref == "master"}
+      assert_equal matched_base_pull_requests.collect{|pr| pr[:base][:ref] }, prw.pull_requests_for_base_branch("master").collect{|pr| pr[:base][:ref] }
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,6 +9,7 @@ require './lib/thumbs'
 require 'vcr'
 require 'log4r'
 
+TESTBRANCH='feature_1474522484'
 TESTREPO='thumbot/prtester'
 TEST_PRW=Thumbs::PullRequestWorker.new(:repo => TESTREPO, :pr => 453)
 TESTPR=453

--- a/test/test_payload.rb
+++ b/test/test_payload.rb
@@ -49,4 +49,21 @@ unit_tests do
 
   end
 
+  test "can detect new base payload type" do
+    new_base_payload = {
+        'action' => 'edited',
+        'changes' => {
+            'base' => {
+                'ref' => {
+                  'from' => 'master'
+                },
+                'sha' => {
+                  'from' => 'afadb0afefe87362ca819a4a78b5bc89dede3133'
+                }
+            }
+        }
+    }
+
+    assert payload_type(new_base_payload) == :new_base, payload_type(new_base_payload).to_s
+  end
 end

--- a/test/test_payload.rb
+++ b/test/test_payload.rb
@@ -66,4 +66,5 @@ unit_tests do
 
     assert payload_type(new_base_payload) == :new_base, payload_type(new_base_payload).to_s
   end
+
 end

--- a/test/test_payload.rb
+++ b/test/test_payload.rb
@@ -49,37 +49,37 @@ unit_tests do
 
   end
 
-  # test "can detect new base payload type" do
-  #   new_base_payload = {
-  #       'action' => 'edited',
-  #       'changes' => {
-  #           'base' => {
-  #               'ref' => {
-  #                 'from' => 'master'
-  #               },
-  #               'sha' => {
-  #                 'from' => 'afadb0afefe87362ca819a4a78b5bc89dede3133'
-  #               }
-  #           }
-  #       }
-  #   }
-  #
-  #   assert payload_type(new_base_payload) == :new_base, payload_type(new_base_payload).to_s
-  # end
-  #
-  # test "can detect merged base payload type" do
-  #   merged_base_payload = {
-  #
-  #       'ref' => 'refs/heads/master',
-  #       'before' => 'e65bc8ef21630b917ca9ecc62adb3b17c1cbe2ef',
-  #       'after' => '34ae62fe74815d254b78c5b1c57979dd8b9e4de5',
-  #       'commits' => [],
-  #       'head_commit' => {},
-  #       'pusher' => { 'name' => 'thumbot',
-  #                     'email' => 'git.thumbs@gmail.com'},
-  #       'repository' => {'full_name' => 'org/user' }
-  #   }
-  #
-  #   assert payload_type(merged_base_payload) == :merged_base, payload_type(merged_base_payload).to_s
-  # end
+  test "can detect new base payload type" do
+    new_base_payload = {
+        'action' => 'edited',
+        'changes' => {
+            'base' => {
+                'ref' => {
+                  'from' => 'master'
+                },
+                'sha' => {
+                  'from' => 'afadb0afefe87362ca819a4a78b5bc89dede3133'
+                }
+            }
+        }
+    }
+
+    assert payload_type(new_base_payload) == :new_base, payload_type(new_base_payload).to_s
+  end
+
+  test "can detect merged base payload type" do
+    merged_base_payload = {
+
+        'ref' => 'refs/heads/master',
+        'before' => 'e65bc8ef21630b917ca9ecc62adb3b17c1cbe2ef',
+        'after' => '34ae62fe74815d254b78c5b1c57979dd8b9e4de5',
+        'commits' => [],
+        'head_commit' => {},
+        'pusher' => { 'name' => 'thumbot',
+                      'email' => 'git.thumbs@gmail.com'},
+        'repository' => {'full_name' => 'org/user' }
+    }
+
+    assert payload_type(merged_base_payload) == :merged_base, payload_type(merged_base_payload).to_s
+  end
 end

--- a/test/test_payload.rb
+++ b/test/test_payload.rb
@@ -24,7 +24,7 @@ unit_tests do
         'weird' => {}
     }
 
-    assert payload_type(strange_payload) == :unregistered
+    assert payload_type(strange_payload) == :unregistered, payload_type(strange_payload).inspect
   end
 
   test "can detect new_push payload type" do
@@ -49,22 +49,37 @@ unit_tests do
 
   end
 
-  test "can detect new base payload type" do
-    new_base_payload = {
-        'action' => 'edited',
-        'changes' => {
-            'base' => {
-                'ref' => {
-                  'from' => 'master'
-                },
-                'sha' => {
-                  'from' => 'afadb0afefe87362ca819a4a78b5bc89dede3133'
-                }
-            }
-        }
-    }
-
-    assert payload_type(new_base_payload) == :new_base, payload_type(new_base_payload).to_s
-  end
-
+  # test "can detect new base payload type" do
+  #   new_base_payload = {
+  #       'action' => 'edited',
+  #       'changes' => {
+  #           'base' => {
+  #               'ref' => {
+  #                 'from' => 'master'
+  #               },
+  #               'sha' => {
+  #                 'from' => 'afadb0afefe87362ca819a4a78b5bc89dede3133'
+  #               }
+  #           }
+  #       }
+  #   }
+  #
+  #   assert payload_type(new_base_payload) == :new_base, payload_type(new_base_payload).to_s
+  # end
+  #
+  # test "can detect merged base payload type" do
+  #   merged_base_payload = {
+  #
+  #       'ref' => 'refs/heads/master',
+  #       'before' => 'e65bc8ef21630b917ca9ecc62adb3b17c1cbe2ef',
+  #       'after' => '34ae62fe74815d254b78c5b1c57979dd8b9e4de5',
+  #       'commits' => [],
+  #       'head_commit' => {},
+  #       'pusher' => { 'name' => 'thumbot',
+  #                     'email' => 'git.thumbs@gmail.com'},
+  #       'repository' => {'full_name' => 'org/user' }
+  #   }
+  #
+  #   assert payload_type(merged_base_payload) == :merged_base, payload_type(merged_base_payload).to_s
+  # end
 end

--- a/test/test_persisted_build_status.rb
+++ b/test/test_persisted_build_status.rb
@@ -1,81 +1,84 @@
-
-
 unit_tests do
 
   test "should be able to read build status" do
-   default_vcr_state do
-    cassette(:load_pr) do
-      prw=Thumbs::PullRequestWorker.new(:repo=>TESTREPO, :pr=>TESTPR)
-      assert prw.build_status.key?(:steps)
-      assert prw.build_status[:steps].key?(:merge)
-      assert prw.build_status[:steps].keys.length == 1
-
-      cassette(:read_build_status) do
-
-        prw.run_build_steps
-
-        status = prw.read_build_status
-        repo=prw.repo.gsub(/\//, '_')
-        file=File.join('/tmp/thumbs', "#{repo}_#{prw.most_recent_sha}.yml")
-
-        parsed_file = File.exist?(file) ?  YAML.load(IO.read(file)) : nil
-        assert parsed_file.keys.sort == status.keys.sort
-        assert status.kind_of?(Hash)
-        assert status.key?(:steps)
-        assert status[:steps].key?(:merge)
-        assert status[:steps].key?(:make), status[:steps].inspect
-        assert status[:steps].key?(:make_test), status[:steps].inspect
-
-        assert prw.build_status[:steps].keys.length == [:merge, :make, :make_test].length, prw.build_status[:steps].keys.inspect
-      end
-    end
-   end
-
-  end
-  test "should be able to persist build status with utf8 and other bad characters" do
     default_vcr_state do
       cassette(:load_pr) do
-        prw=Thumbs::PullRequestWorker.new(:repo=>TESTREPO, :pr=>TESTPR)
-        cassette(:get_events_reload, :record => :new_episodes) do
+        prw=Thumbs::PullRequestWorker.new(:repo => TESTREPO, :pr => TESTPR)
+        assert prw.build_status.key?(:steps)
+        assert prw.build_status[:steps].key?(:merge)
+        assert prw.build_status[:steps].keys.length == 1
 
+        cassette(:read_build_status) do
           prw.run_build_steps
-        test_content=IO.read(File.join(File.dirname(__FILE__), "/data/test_utf8_build_status.txt"))
-        prw.build_status[:steps][:make][:output] = test_content
-        prw.persist_build_status
-        status = prw.read_build_status
-        assert_equal prw.build_status[:steps][:make], status[:steps][:make]
-      end
-    end
-    end
-  end
-
-  def sanitize_text(text)
-    text.encode('UTF-8', 'UTF-8', :invalid => :replace, :undef => :replace)
-  end
-  test "should fix bad utf8 byte sequence" do
-    bad_test_string="hi \255"
-    assert_raise(ArgumentError) do
-      test_split = bad_test_string.split(' ')
-    end
-
-    fixed_bad_test_string=sanitize_text(bad_test_string)
-    test_split = fixed_bad_test_string.split(' ')
-    default_vcr_state do
-      cassette(:load_pr) do
-        prw=Thumbs::PullRequestWorker.new(:repo=>TESTREPO, :pr=>TESTPR)
-        cassette(:get_events_reload, :record => :new_episodes) do
-          prw.run_build_steps
-          prw.build_status[:steps][:make][:output]=bad_test_string
-
           prw.persist_build_status
-          fixed_persisted_bad_test_string = prw.read_build_status[:steps][:make][:output]
-          assert_equal "hi �", fixed_persisted_bad_test_string
+          cassette(:get_commits_for_branch, :record => :new_episodes) do
+            status = prw.read_build_status
+
+            repo=prw.repo.gsub(/\//, '_')
+            file=File.join('/tmp/thumbs', "#{repo}_#{prw.build_guid}.yml")
+
+            parsed_file = File.exist?(file) ? YAML.load(IO.read(file)) : nil
+            assert parsed_file.keys.sort == status.keys.sort
+            assert status.kind_of?(Hash)
+            assert status.key?(:steps)
+            assert status[:steps].key?(:merge)
+            assert status[:steps].key?(:make), status[:steps].inspect
+            assert status[:steps].key?(:make_test), status[:steps].inspect
+
+            assert prw.build_status[:steps].keys.length == [:merge, :make, :make_test].length, prw.build_status[:steps].keys.inspect
+          end
         end
       end
     end
 
   end
-end
+  test "should be able to persist build status with utf8 and other bad characters" do
+    default_vcr_state do
+      cassette(:load_pr) do
+        prw=Thumbs::PullRequestWorker.new(:repo => TESTREPO, :pr => TESTPR)
+        cassette(:get_events_reload, :record => :new_episodes) do
+          cassette(:get_events_reload2, :record => :new_episodes) do
+
+            prw.run_build_steps
+            test_content=IO.read(File.join(File.dirname(__FILE__), "/data/test_utf8_build_status.txt"))
+            prw.build_status[:steps][:make][:output] = test_content
+            prw.persist_build_status
+            status = prw.read_build_status
+            assert_equal prw.build_status[:steps][:make], status[:steps][:make]
+          end
+        end
+      end
+    end
+  end
+
+    def sanitize_text(text)
+      text.encode('UTF-8', 'UTF-8', :invalid => :replace, :undef => :replace)
+    end
+
+    test "should fix bad utf8 byte sequence" do
+      bad_test_string="hi \255"
+      assert_raise(ArgumentError) do
+        test_split = bad_test_string.split(' ')
+      end
+
+      fixed_bad_test_string=sanitize_text(bad_test_string)
+      test_split = fixed_bad_test_string.split(' ')
+      default_vcr_state do
+        cassette(:load_pr) do
+          prw=Thumbs::PullRequestWorker.new(:repo => TESTREPO, :pr => TESTPR)
+          cassette(:get_events_reload, :record => :new_episodes) do
+            prw.run_build_steps
+            prw.build_status[:steps][:make][:output]=bad_test_string
+
+            prw.persist_build_status
+            fixed_persisted_bad_test_string = prw.read_build_status[:steps][:make][:output]
+            assert_equal "hi �", fixed_persisted_bad_test_string
+          end
+        end
+      end
+
+    end
+  end
 
 
 

--- a/test/test_persisted_build_status.rb
+++ b/test/test_persisted_build_status.rb
@@ -14,7 +14,7 @@ unit_tests do
 
         prw.run_build_steps
 
-        status = prw.read_build_status(prw.repo, prw.most_recent_sha)
+        status = prw.read_build_status
         repo=prw.repo.gsub(/\//, '_')
         file=File.join('/tmp/thumbs', "#{repo}_#{prw.most_recent_sha}.yml")
 
@@ -40,7 +40,7 @@ unit_tests do
         test_content=IO.read(File.join(File.dirname(__FILE__), "/data/test_utf8_build_status.txt"))
         prw.build_status[:steps][:make][:output] = test_content
         prw.persist_build_status
-        status = prw.read_build_status(prw.repo, prw.most_recent_sha)
+        status = prw.read_build_status
         assert_equal prw.build_status[:steps][:make], status[:steps][:make]
       end
     end
@@ -63,7 +63,7 @@ unit_tests do
         prw.build_status[:steps][:make][:output]=bad_test_string
 
         prw.persist_build_status
-        fixed_persisted_bad_test_string = prw.read_build_status(prw.repo, prw.most_recent_sha)[:steps][:make][:output]
+        fixed_persisted_bad_test_string = prw.read_build_status[:steps][:make][:output]
         assert_equal "hi �", fixed_persisted_bad_test_string
       end
     end

--- a/test/test_persisted_build_status.rb
+++ b/test/test_persisted_build_status.rb
@@ -36,7 +36,9 @@ unit_tests do
     default_vcr_state do
       cassette(:load_pr) do
         prw=Thumbs::PullRequestWorker.new(:repo=>TESTREPO, :pr=>TESTPR)
-        prw.run_build_steps
+        cassette(:get_events_reload, :record => :new_episodes) do
+
+          prw.run_build_steps
         test_content=IO.read(File.join(File.dirname(__FILE__), "/data/test_utf8_build_status.txt"))
         prw.build_status[:steps][:make][:output] = test_content
         prw.persist_build_status
@@ -44,7 +46,9 @@ unit_tests do
         assert_equal prw.build_status[:steps][:make], status[:steps][:make]
       end
     end
+    end
   end
+
   def sanitize_text(text)
     text.encode('UTF-8', 'UTF-8', :invalid => :replace, :undef => :replace)
   end
@@ -59,12 +63,14 @@ unit_tests do
     default_vcr_state do
       cassette(:load_pr) do
         prw=Thumbs::PullRequestWorker.new(:repo=>TESTREPO, :pr=>TESTPR)
-        prw.run_build_steps
-        prw.build_status[:steps][:make][:output]=bad_test_string
+        cassette(:get_events_reload, :record => :new_episodes) do
+          prw.run_build_steps
+          prw.build_status[:steps][:make][:output]=bad_test_string
 
-        prw.persist_build_status
-        fixed_persisted_bad_test_string = prw.read_build_status[:steps][:make][:output]
-        assert_equal "hi �", fixed_persisted_bad_test_string
+          prw.persist_build_status
+          fixed_persisted_bad_test_string = prw.read_build_status[:steps][:make][:output]
+          assert_equal "hi �", fixed_persisted_bad_test_string
+        end
       end
     end
 

--- a/test/test_state.rb
+++ b/test/test_state.rb
@@ -30,36 +30,4 @@ unit_tests do
 
   end
 
-  test "set build progress when running build steps" do
-    cassette(:load_stuff, :allow_playback_repeats => true) do
-      prw=Thumbs::PullRequestWorker.new(:repo => TESTREPO, :pr => TESTPR)
-      cassette(:load_stuff_other, :allow_playback_repeats => true) do
-        cassette(:build_progress_steps, :allow_playback_repeats => true, :record => :all) do
-
-
-          default_vcr_state do
-            prw.clear_build_progress_comment
-
-            cassette(:build_in_progress_test, :allow_playback_repeats => true, :record => :all) do
-              cassette(:build_in_progress_test2, :allow_playback_repeats => true, :record => :all) do
-
-                assert_false prw.build_in_progress?
-
-                assert_equal :unstarted, prw.build_progress_status
-                prw.build_steps=["find /tmp"]
-                prw.thumb_config['timeout']=5
-                prw.set_build_progress(:in_progress)
-                assert_equal :in_progress, prw.build_progress_status
-                prw.set_build_progress(:completed)
-                assert_equal :completed, prw.build_progress_status
-
-              end
-            end
-
-          end
-        end
-      end
-    end
-  end
 end
-

--- a/test/test_webhook.rb
+++ b/test/test_webhook.rb
@@ -90,10 +90,6 @@ class WebhookTest < Test::Unit::TestCase
     cassette(:load_pr, :record => :new_episodes) do
       prw = Thumbs::PullRequestWorker.new(:repo => 'thumbot/prtester', :pr => TESTPR)
 
-      build_dir="/tmp/thumbs/#{prw.repo.gsub(/\//, '_')}_#{prw.pr.head.sha.slice(0, 10)}"
-      FileUtils.rm_rf(build_dir)
-      assert_equal false, File.exist?(build_dir)
-
       new_pr_webhook_payload = {
           'repository' => {'full_name' => prw.repo},
           'number' => prw.pr.number,
@@ -104,7 +100,6 @@ class WebhookTest < Test::Unit::TestCase
       remove_comments(prw.repo, prw.pr.number)
       cassette(:get_comments, :record => :all) do
         cassette(:get_issue_comments, :record => :all) do
-          original_comments_length=prw.comments.length
 
           cassette(:post_webhook_new_pr, :record => :all) do
 
@@ -173,3 +168,11 @@ end
 
 
 # end
+
+
+#
+# 2.3.0 :015 >   prw.client.pull_requests(prw.repo, :state => 'open').collect{|pr| pr if pr.base.ref == 'master'}.length
+
+
+
+# prw.client.pull_requests(prw.repo, :state => 'open')

--- a/test/test_webhook.rb
+++ b/test/test_webhook.rb
@@ -85,6 +85,33 @@ class WebhookTest < Test::Unit::TestCase
   def test_new_comment_hook
 
   end
+  def test_merged_pr_hook
+      default_vcr_state do
+        prw = Thumbs::PullRequestWorker.new(:repo => TESTREPO, :pr => TESTPR)
+
+        merged_pr_payload = {
+
+            'refs' => 'refs/heads/master',
+            'before' => 'e65bc8ef21630b917ca9ecc62adb3b17c1cbe2ef',
+            'after' => '34ae62fe74815d254b78c5b1c57979dd8b9e4de5',
+            'commits' => [],
+            'head_commit' => {},
+            'pusher' => { 'name' => 'thumbot',
+                          'email' => 'git.thumbs@gmail.com'},
+            'repository' => {'full_name' => prw.repo }
+        }
+        cassette(:get_comments, :record => :all) do
+          cassette(:get_issue_comments, :record => :new_episodes) do
+            cassette(:post_webhook_merged_pr, :record => :new_episodes) do
+              post '/webhook', merged_pr_payload.to_json do
+                assert last_response.body.include?("OK"), last_response.body
+              end
+            end
+          end
+        end
+      end
+    end
+
 
   def test_new_pr_hook
     cassette(:load_pr, :record => :new_episodes) do
@@ -112,67 +139,3 @@ class WebhookTest < Test::Unit::TestCase
     end
   end
 end
-
-
-# def test_webhook_mergeable_pr_test
-#   VCR.use_cassette(:create_pr) do
-#
-#     prw = create_test_pr("thumbot/prtester")
-#
-#
-#   assert prw.comments.length == 0
-#   assert prw.review_count == 0
-#   assert prw.bot_comments.length == 0
-#
-#   new_pr_webhook_payload = {
-#       'repository' => {'full_name' => prw.repo},
-#       'number' => prw.pr.number,
-#       'pull_request' => {'number' => prw.pr.number, 'body' => prw.pr.body}
-#   }
-#
-#   post '/webhook', new_pr_webhook_payload.to_json
-#
-#   assert_true last_response.body.include?("OK"), last_response.body
-#
-#   assert_true prw.open?
-#   assert prw.review_count == 0
-#
-#   assert prw.comments.length == 1
-#   assert prw.bot_comments.length == 1
-#   assert_true prw.open?
-#
-#   assert prw.comments.first['body'] =~ /Build Status/
-#
-#   create_test_code_reviews(prw.repo, prw.pr.number)
-#
-#   assert prw.review_count >= 2
-#
-#   new_comment_payload = {
-#       'repository' => {'full_name' => prw.repo},
-#       'issue' => {'number' => prw.pr.number,
-#                   'pull_request' => {}
-#       },
-#       'comment' => {'body' => "looks good"}
-#   }
-#
-#   assert payload_type(new_comment_payload) == :new_comment, payload_type(new_comment_payload).to_s
-#
-#   post "/webhook", new_comment_payload.to_json
-#
-#   assert last_response.body.include?("OK"), last_response.body
-#
-#   assert_false prw.open?
-#   prw.close
-#
-# end
-
-
-# end
-
-
-#
-# 2.3.0 :015 >   prw.client.pull_requests(prw.repo, :state => 'open').collect{|pr| pr if pr.base.ref == 'master'}.length
-
-
-
-# prw.client.pull_requests(prw.repo, :state => 'open')

--- a/test/test_webhook.rb
+++ b/test/test_webhook.rb
@@ -122,7 +122,8 @@ class WebhookTest < Test::Unit::TestCase
           'number' => prw.pr.number,
           'pull_request' => {'number' => prw.pr.number, 'body' => prw.pr.body}
       }
-      assert prw.build_status[:steps].keys.length == 1
+      prw.unpersist_build_status
+      assert prw.build_status[:steps].keys.length == 1 ,prw.build_status[:steps].inspect
       assert prw.build_status[:steps].key?(:merge)
       remove_comments(prw.repo, prw.pr.number)
       cassette(:get_comments, :record => :all) do


### PR DESCRIPTION
This enables the behavior that after a pr is merged, it triggers rebuilds of all other prs with a base that is affected. 
After a pr merges you should see near simultaneous build status comments on all the other prs while it gets worked on.
This also includes a fix that correctly identifies the most recent base sha.
"pr.base.sha" should be the most recent commit sha for the base ref branch, however for some reason github caches this value and could be out of date. 

Example below of builds being triggered on different base sha versions. 

![example](http://i.imgur.com/1YOzSe2.png)

Example pr: https://github.com/davidx/prtester/pull/262
