### PR TITLE
Counting code approval support

### DIFF
--- a/.thumbs.yml
+++ b/.thumbs.yml
@@ -4,4 +4,4 @@ build_steps:
  - env
  - bundle exec ruby test/test.rb
 org_mode: true
-timeout: 1802
+timeout: 1803

--- a/.thumbs.yml
+++ b/.thumbs.yml
@@ -4,4 +4,4 @@ build_steps:
  - env
  - bundle exec ruby test/test.rb
 org_mode: true
-timeout: 1801
+timeout: 1802

--- a/.thumbs.yml
+++ b/.thumbs.yml
@@ -3,4 +3,4 @@ merge: true
 build_steps:
  - bundle exec ruby test/test.rb
 org_mode: true
-timeout: 1799
+timeout: 1800

--- a/.thumbs.yml
+++ b/.thumbs.yml
@@ -1,6 +1,7 @@
 minimum_reviewers: 2
 merge: true
 build_steps:
+ - env
  - bundle exec ruby test/test.rb
 org_mode: true
 timeout: 1801

--- a/.thumbs.yml
+++ b/.thumbs.yml
@@ -3,4 +3,4 @@ merge: true
 build_steps:
  - bundle exec ruby test/test.rb
 org_mode: true
-timeout: 1800
+timeout: 1801

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'unicorn'
 gem 'netrc'
 gem 'activesupport'
 gem 'nokogiri', '1.6.8.1'
-gem 'graphql-client'
+gem 'graphql-client', :require => 'graphql/client'
 
 group :test, :development do
   gem 'vcr'

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,8 @@ source 'https://rubygems.org'
 gem 'test-unit'
 
 gem 'sinatra', '2.0.0.beta2'
+gem 'graphql-client', '~> 0.2.3'
+gem 'nokogiri', '1.6.8.1'
 gem 'rack'
 gem 'rake'
 gem 'rack-test'
@@ -13,8 +15,6 @@ gem 'git'
 gem 'unicorn'
 gem 'netrc'
 gem 'activesupport'
-gem 'nokogiri', '1.6.8.1'
-gem 'graphql-client', :require => 'graphql/client'
 
 group :test, :development do
   gem 'vcr'
@@ -23,4 +23,3 @@ group :test, :development do
   gem 'capybara'
   gem 'rspec-rails'
 end
-

--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem 'unicorn'
 gem 'netrc'
 gem 'activesupport'
 gem 'nokogiri', '1.6.8.1'
+gem 'graphql-client'
 
 group :test, :development do
   gem 'vcr'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,6 +39,10 @@ GEM
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     git (1.3.0)
+    graphql (0.19.4)
+    graphql-client (0.2.1)
+      activesupport (>= 3.0, < 6.0)
+      graphql (~> 0.19, >= 0.19.2)
     hashdiff (0.3.0)
     http (2.0.3)
       addressable (~> 2.3)
@@ -141,6 +145,7 @@ DEPENDENCIES
   capybara
   dust
   git
+  graphql-client
   http
   log4r
   netrc

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,10 +39,10 @@ GEM
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     git (1.3.0)
-    graphql (0.19.4)
-    graphql-client (0.2.1)
+    graphql (1.0.0)
+    graphql-client (0.2.3)
       activesupport (>= 3.0, < 6.0)
-      graphql (~> 0.19, >= 0.19.2)
+      graphql (>= 0.19.2)
     hashdiff (0.3.0)
     http (2.0.3)
       addressable (~> 2.3)
@@ -145,7 +145,7 @@ DEPENDENCIES
   capybara
   dust
   git
-  graphql-client
+  graphql-client (~> 0.2.3)
   http
   log4r
   netrc

--- a/lib/thumbs.rb
+++ b/lib/thumbs.rb
@@ -7,12 +7,50 @@ require 'git'
 require 'erb'
 require 'netrc'
 require 'http'
-
+require "graphql/client"
+require "graphql/client/http"
+require 'net/http'
+require 'active_support'
 
 require 'thumbs/general_helpers'
 require 'thumbs/webhook_helpers'
 require 'thumbs/pull_request_worker'
 
+
+
+
+module Thumbs
+  module GitHub
+    def self.dump(file)
+      GraphQL::Client.dump_schema(Thumbs::GitHub::HTTP, file)
+    end
+
+    def self.load(file)
+      GraphQL::Client.load_schema(file)
+    end
+  end
+end
+
+module Thumbs
+  module GitHub
+    HTTP = GraphQL::Client::HTTP.new("https://api.github.com/graphql") do
+      def headers(context)
+        {
+            "Authorization" => "Bearer #{ENV['GITHUB_ACCESS_TOKEN']}"
+        }
+      end
+    end
+    file='schema.json'
+    dump(file) unless File.exists?(file)
+
+    Schema = load(file)
+    Client = GraphQL::Client.new(
+        schema: Schema,
+        execute: HTTP
+    )
+
+  end
+end
 
 module Thumbs
   def self.start_logger

--- a/lib/thumbs/pull_request_worker.rb
+++ b/lib/thumbs/pull_request_worker.rb
@@ -184,8 +184,7 @@ module Thumbs
     end
 
     def org_member_code_reviews
-      org_member_code_review_comments=org_member_comments.collect { |comment| comment if contains_plus_one?(comment[:body]) }.compact
-      org_member_code_review_comments.collect { |r| r[:user][:login] }.uniq.length
+      org_member_comments.collect { |comment| comment if contains_plus_one?(comment[:body]) }.compact
     end
 
     def code_reviews

--- a/lib/thumbs/pull_request_worker.rb
+++ b/lib/thumbs/pull_request_worker.rb
@@ -731,7 +731,7 @@ module Thumbs
       most_recent_timestamp=commit[:commit][:committer][:date].to_s
       approval_entries=get_reviews_by_pr_id(id).collect{|r| r if r['state'] == 'APPROVED'}.compact
 
-      approval_entries.collect do |a|
+      approval_entries=approval_entries.collect do |a|
         approval_timestamp_int=DateTime.parse(a['submittedAt'])
         most_recent_timestamp_int=DateTime.parse(most_recent_timestamp)
         a if approval_timestamp_int > most_recent_timestamp_int

--- a/lib/thumbs/pull_request_worker.rb
+++ b/lib/thumbs/pull_request_worker.rb
@@ -739,7 +739,7 @@ module Thumbs
       get_approvals(get_pull_request_id).collect { |approval| approval if @client.organization_member?(org, approval["author"]["login"]) }.compact
     end
     def approvals
-      if thumb_config.key?('org_mode') && thumb_config['org_mode']
+      if @thumb_config.key?('org_mode') && @thumb_config['org_mode']
         debug_message "returning org_member_code_approvals"
         return org_member_approvals
       end

--- a/lib/thumbs/pull_request_worker.rb
+++ b/lib/thumbs/pull_request_worker.rb
@@ -148,9 +148,6 @@ module Thumbs
       time_stamp ? time_stamp : pr.created_at
     end
 
-    def approvals_after_head_sha
-
-    end
     def comments_after_head_sha
       sha_time_stamp=push_time_stamp(most_recent_head_sha)
       comments_after_sha=all_comments.compact.collect do |c|

--- a/lib/thumbs/pull_request_worker.rb
+++ b/lib/thumbs/pull_request_worker.rb
@@ -1,5 +1,3 @@
-require 'http'
-require 'etc'
 module Thumbs
   class PullRequestWorker
 
@@ -11,10 +9,12 @@ module Thumbs
     attr_reader :pr
     attr_accessor :thumb_config
     attr_reader :log
+    attr_reader :org
     attr_accessor :client
 
     def initialize(options)
       @repo = options[:repo]
+      @org = repo.split('/').first
       @client = Octokit::Client.new(:netrc => true)
       @pr = @client.pull_request(options[:repo], options[:pr])
       @build_dir=options[:build_dir] || "/tmp/thumbs/#{build_guid}"
@@ -148,6 +148,9 @@ module Thumbs
       time_stamp ? time_stamp : pr.created_at
     end
 
+    def approvals_after_head_sha
+
+    end
     def comments_after_head_sha
       sha_time_stamp=push_time_stamp(most_recent_head_sha)
       comments_after_sha=all_comments.compact.collect do |c|
@@ -181,7 +184,8 @@ module Thumbs
     end
 
     def org_member_code_reviews
-      org_member_comments.collect { |comment| comment if contains_plus_one?(comment[:body]) }.compact
+      org_member_code_review_comments=org_member_comments.collect { |comment| comment if contains_plus_one?(comment[:body]) }.compact
+      org_member_code_review_comments.collect { |r| r[:user][:login] }.uniq.length
     end
 
     def code_reviews
@@ -189,18 +193,11 @@ module Thumbs
     end
 
     def review_count
-      debug_message "reviews"
-      debug_message reviews.collect { |r| r[:user][:login] }.uniq
-      reviews.collect { |r| r[:user][:login] }.uniq.length
+      approvals.collect{|a| a["author"]["login"] }.uniq.length + comment_code_approvals.collect { |r| r[:user][:login] }.uniq.length
     end
 
     def reviews
-      if @thumb_config['org_mode']
-        debug_message "returning org_member_code_reviews"
-        return org_member_code_reviews
-      end
-
-      code_reviews
+      (approvals + comment_code_approvals).compact
     end
 
     def debug_message(message)
@@ -376,8 +373,6 @@ module Thumbs
       build_progress_comment = get_build_progress_comment
       build_progress_comment ? client.delete_comment(repo, build_progress_comment[:id]) : true
     end
-
-
 
     def pushes
       events.collect { |e| e if e[:type] == 'PushEvent' }.compact
@@ -644,7 +639,12 @@ module Thumbs
 <details>
 <summary><%= result_image(status_code) %> <%= review_count %> of <%= minimum_reviewers %> Code reviews<%= org_msg %></summary>
 <% reviews.each do |review| %>
-- @<%= review[:user][:login] %>: <%= review[:body] %> 
+  <% if review.key?(:user) && review[:user].key?(:login) %>
+  - @<%= review[:user][:login] %>: <%= review[:body] %> 
+  <% end %>
+  <% if review.key?("author") && review["author"].key?("login") %>
+  - @<%= review["author"]["login"] %>:  <% review["body"] %>
+  <% end %>
 <% end %>
 </details>
       EOS
@@ -675,6 +675,103 @@ module Thumbs
       @thumb_config
     end
 
+    def get_open_pull_requests_for_repo
+      org,repo_name = @repo.split('/')
+      GitHub::Client.parse <<-GRAPHQL
+        query {
+          repositoryOwner(login: "#{org}"){
+            repository(name: "#{repo_name}") {
+              pullRequests(states:OPEN, last: 20) {
+                edges {
+                  node{
+                    id
+                    number
+                  }
+                }
+              }
+            }
+          }
+        }
+      GRAPHQL
+    end
+
+    def get_pull_request_id
+      pr_list=run_graph_query( get_open_pull_requests_for_repo ).data.to_h
+      pr_list['repositoryOwner']['repository']['pullRequests']['edges'].collect{|n| n['node']['id'] if n['node']['number'] == pr.number }.compact.first
+    end
+    def get_pull_request_by_id(id)
+      GitHub::Client.parse <<-GRAPHQL
+   query {
+    node(id: "#{id}") {
+      ... on PullRequest {
+          id
+          number
+          reviews(last:30) {
+            edges {
+              node {
+                author {
+                  id
+                  name
+                  login
+                }
+                body                 
+                state
+                submittedAt
+              }
+            }
+          }
+        }
+      }
+   }
+      GRAPHQL
+    end
+
+
+    def get_approvals(id)
+      commit=client.commit(repo, most_recent_head_sha).to_h
+      most_recent_timestamp=commit[:commit][:committer][:date].to_s
+      approval_entries=get_reviews_by_pr_id(id).collect{|r| r if r['state'] == 'APPROVED'}.compact
+
+      approval_entries.collect do |a|
+        approval_timestamp_int=DateTime.parse(a['submittedAt'])
+        most_recent_timestamp_int=DateTime.parse(most_recent_timestamp)
+        a if approval_timestamp_int > most_recent_timestamp_int
+      end
+      approval_entries.compact
+    end
+    def org_member_approvals
+      get_approvals(get_pull_request_id).collect { |approval| approval if @client.organization_member?(org, approval["author"]["login"]) }.compact
+    end
+    def approvals
+      if thumb_config.key?('org_mode') && thumb_config['org_mode']
+        debug_message "returning org_member_code_approvals"
+        return org_member_approvals
+      end
+      get_approvals(get_pull_request_id)
+    end
+    def approval_count
+      approvals.collect{|a| a["author"]["login"] }.uniq.length
+    end
+    def comment_code_approval_count
+      comment_code_approvals.collect { |r| r[:user][:login] }.uniq.length
+    end
+
+    def get_reviews_by_pr_id(id)
+      pr_hash = run_graph_query( get_pull_request_by_id(id) ).data.to_h['node']
+      pr_hash ? (pr_hash.key?('reviews') ? pr_hash['reviews']['edges'].collect{|e| e['node'] } : [] ) : []
+    end
+
+    def run_graph_query(query)
+      GitHub::Client.query query
+    end
+    def comment_code_approvals
+      if @thumb_config['org_mode']
+        debug_message "returning org_member_code_reviews"
+        return org_member_code_reviews
+      end
+
+      code_reviews
+    end
     private
 
     def render_template(template)

--- a/lib/thumbs/webhook_helpers.rb
+++ b/lib/thumbs/webhook_helpers.rb
@@ -26,7 +26,7 @@ module Sinatra
           payload.key?('review') &&
           payload['review'].key?('state') &&
           payload['review']['state'] == 'commented'
-      return :code_change_request if payload['action'] == 'submitted' &&
+      return :code_change_requested if payload['action'] == 'submitted' &&
           payload.key?('review') &&
           payload['review'].key?('state') &&
           payload['review']['state'] == 'changes_requested'
@@ -35,7 +35,7 @@ module Sinatra
 
     def process_payload(payload)
       case payload_type(payload)
-        when :code_change_request
+        when :code_change_requested
           debug_message "code change payload"
           [payload['repository']['full_name'], payload['pull_request']['number']]
         when :code_comment

--- a/lib/thumbs/webhook_helpers.rb
+++ b/lib/thumbs/webhook_helpers.rb
@@ -18,15 +18,34 @@ module Sinatra
         matched_keys=merged_base_keys.collect{|key| key if payload.key?(key) }.compact
         return :merged_base if (matched_keys.length == merged_base_keys.length)
       end
+      return :code_approval if payload['action'] == 'submitted' &&
+          payload.key?('review') &&
+          payload['review'].key?('state') &&
+          payload['review']['state'] == 'approved'
+      return :code_comment if payload['action'] == 'submitted' &&
+          payload.key?('review') &&
+          payload['review'].key?('state') &&
+          payload['review']['state'] == 'commented'
+      return :code_change_request if payload['action'] == 'submitted' &&
+          payload.key?('review') &&
+          payload['review'].key?('state') &&
+          payload['review']['state'] == 'changes_requested'
       :unregistered
     end
 
     def process_payload(payload)
       case payload_type(payload)
+        when :code_change_request
+          debug_message "code change payload"
+          [payload['repository']['full_name'], payload['pull_request']['number']]
+        when :code_comment
+          debug_message "code comment payload"
+          [payload['repository']['full_name'], payload['pull_request']['number']]
+        when :code_approval
+          debug_message "code approval payload"
+          [payload['repository']['full_name'], payload['pull_request']['number']]
         when :merged_base
           debug_message "merged_base payload"
-          print payload.to_yaml
-          print "payload"
           base=payload['ref'].split('/').pop
           [payload['repository']['full_name'], base]
         when :new_base

--- a/test/fixtures/approval.yml
+++ b/test/fixtures/approval.yml
@@ -1,0 +1,412 @@
+---
+action: submitted
+review:
+  id: 6523994
+  user:
+    login: davidpuddy1
+    id: 20779719
+    avatar_url: https://avatars.githubusercontent.com/u/20779719?v=3
+    gravatar_id: ''
+    url: https://api.github.com/users/davidpuddy1
+    html_url: https://github.com/davidpuddy1
+    followers_url: https://api.github.com/users/davidpuddy1/followers
+    following_url: https://api.github.com/users/davidpuddy1/following{/other_user}
+    gists_url: https://api.github.com/users/davidpuddy1/gists{/gist_id}
+    starred_url: https://api.github.com/users/davidpuddy1/starred{/owner}{/repo}
+    subscriptions_url: https://api.github.com/users/davidpuddy1/subscriptions
+    organizations_url: https://api.github.com/users/davidpuddy1/orgs
+    repos_url: https://api.github.com/users/davidpuddy1/repos
+    events_url: https://api.github.com/users/davidpuddy1/events{/privacy}
+    received_events_url: https://api.github.com/users/davidpuddy1/received_events
+    type: User
+    site_admin: false
+  body: ''
+  submitted_at: '2016-10-31T20:58:23Z'
+  state: approved
+  html_url: https://github.com/davidx/prtester/pull/296#pullrequestreview-6523994
+  pull_request_url: https://api.github.com/repos/davidx/prtester/pulls/296
+  _links:
+    html:
+      href: https://github.com/davidx/prtester/pull/296#pullrequestreview-6523994
+    pull_request:
+      href: https://api.github.com/repos/davidx/prtester/pulls/296
+pull_request:
+  url: https://api.github.com/repos/davidx/prtester/pulls/296
+  id: 91689123
+  html_url: https://github.com/davidx/prtester/pull/296
+  diff_url: https://github.com/davidx/prtester/pull/296.diff
+  patch_url: https://github.com/davidx/prtester/pull/296.patch
+  issue_url: https://api.github.com/repos/davidx/prtester/issues/296
+  number: 296
+  state: open
+  locked: false
+  title: tester
+  user:
+    login: davidx
+    id: 17162
+    avatar_url: https://avatars.githubusercontent.com/u/17162?v=3
+    gravatar_id: ''
+    url: https://api.github.com/users/davidx
+    html_url: https://github.com/davidx
+    followers_url: https://api.github.com/users/davidx/followers
+    following_url: https://api.github.com/users/davidx/following{/other_user}
+    gists_url: https://api.github.com/users/davidx/gists{/gist_id}
+    starred_url: https://api.github.com/users/davidx/starred{/owner}{/repo}
+    subscriptions_url: https://api.github.com/users/davidx/subscriptions
+    organizations_url: https://api.github.com/users/davidx/orgs
+    repos_url: https://api.github.com/users/davidx/repos
+    events_url: https://api.github.com/users/davidx/events{/privacy}
+    received_events_url: https://api.github.com/users/davidx/received_events
+    type: User
+    site_admin: false
+  body: ''
+  created_at: '2016-10-31T20:56:55Z'
+  updated_at: '2016-10-31T20:58:23Z'
+  closed_at:
+  merged_at:
+  merge_commit_sha: 8322aec89ad84eb1f1b208d513c26370ff0e6da9
+  assignee:
+  assignees: []
+  milestone:
+  commits_url: https://api.github.com/repos/davidx/prtester/pulls/296/commits
+  review_comments_url: https://api.github.com/repos/davidx/prtester/pulls/296/comments
+  review_comment_url: https://api.github.com/repos/davidx/prtester/pulls/comments{/number}
+  comments_url: https://api.github.com/repos/davidx/prtester/issues/296/comments
+  statuses_url: https://api.github.com/repos/davidx/prtester/statuses/11a41e96587c46e4e8da4e1a4b094b29ef7282a3
+  head:
+    label: davidx:1477931168
+    ref: '1477931168'
+    sha: 11a41e96587c46e4e8da4e1a4b094b29ef7282a3
+    user:
+      login: davidx
+      id: 17162
+      avatar_url: https://avatars.githubusercontent.com/u/17162?v=3
+      gravatar_id: ''
+      url: https://api.github.com/users/davidx
+      html_url: https://github.com/davidx
+      followers_url: https://api.github.com/users/davidx/followers
+      following_url: https://api.github.com/users/davidx/following{/other_user}
+      gists_url: https://api.github.com/users/davidx/gists{/gist_id}
+      starred_url: https://api.github.com/users/davidx/starred{/owner}{/repo}
+      subscriptions_url: https://api.github.com/users/davidx/subscriptions
+      organizations_url: https://api.github.com/users/davidx/orgs
+      repos_url: https://api.github.com/users/davidx/repos
+      events_url: https://api.github.com/users/davidx/events{/privacy}
+      received_events_url: https://api.github.com/users/davidx/received_events
+      type: User
+      site_admin: false
+    repo:
+      id: 64998050
+      name: prtester
+      full_name: davidx/prtester
+      owner:
+        login: davidx
+        id: 17162
+        avatar_url: https://avatars.githubusercontent.com/u/17162?v=3
+        gravatar_id: ''
+        url: https://api.github.com/users/davidx
+        html_url: https://github.com/davidx
+        followers_url: https://api.github.com/users/davidx/followers
+        following_url: https://api.github.com/users/davidx/following{/other_user}
+        gists_url: https://api.github.com/users/davidx/gists{/gist_id}
+        starred_url: https://api.github.com/users/davidx/starred{/owner}{/repo}
+        subscriptions_url: https://api.github.com/users/davidx/subscriptions
+        organizations_url: https://api.github.com/users/davidx/orgs
+        repos_url: https://api.github.com/users/davidx/repos
+        events_url: https://api.github.com/users/davidx/events{/privacy}
+        received_events_url: https://api.github.com/users/davidx/received_events
+        type: User
+        site_admin: false
+      private: false
+      html_url: https://github.com/davidx/prtester
+      description: testing pr
+      fork: false
+      url: https://api.github.com/repos/davidx/prtester
+      forks_url: https://api.github.com/repos/davidx/prtester/forks
+      keys_url: https://api.github.com/repos/davidx/prtester/keys{/key_id}
+      collaborators_url: https://api.github.com/repos/davidx/prtester/collaborators{/collaborator}
+      teams_url: https://api.github.com/repos/davidx/prtester/teams
+      hooks_url: https://api.github.com/repos/davidx/prtester/hooks
+      issue_events_url: https://api.github.com/repos/davidx/prtester/issues/events{/number}
+      events_url: https://api.github.com/repos/davidx/prtester/events
+      assignees_url: https://api.github.com/repos/davidx/prtester/assignees{/user}
+      branches_url: https://api.github.com/repos/davidx/prtester/branches{/branch}
+      tags_url: https://api.github.com/repos/davidx/prtester/tags
+      blobs_url: https://api.github.com/repos/davidx/prtester/git/blobs{/sha}
+      git_tags_url: https://api.github.com/repos/davidx/prtester/git/tags{/sha}
+      git_refs_url: https://api.github.com/repos/davidx/prtester/git/refs{/sha}
+      trees_url: https://api.github.com/repos/davidx/prtester/git/trees{/sha}
+      statuses_url: https://api.github.com/repos/davidx/prtester/statuses/{sha}
+      languages_url: https://api.github.com/repos/davidx/prtester/languages
+      stargazers_url: https://api.github.com/repos/davidx/prtester/stargazers
+      contributors_url: https://api.github.com/repos/davidx/prtester/contributors
+      subscribers_url: https://api.github.com/repos/davidx/prtester/subscribers
+      subscription_url: https://api.github.com/repos/davidx/prtester/subscription
+      commits_url: https://api.github.com/repos/davidx/prtester/commits{/sha}
+      git_commits_url: https://api.github.com/repos/davidx/prtester/git/commits{/sha}
+      comments_url: https://api.github.com/repos/davidx/prtester/comments{/number}
+      issue_comment_url: https://api.github.com/repos/davidx/prtester/issues/comments{/number}
+      contents_url: https://api.github.com/repos/davidx/prtester/contents/{+path}
+      compare_url: https://api.github.com/repos/davidx/prtester/compare/{base}...{head}
+      merges_url: https://api.github.com/repos/davidx/prtester/merges
+      archive_url: https://api.github.com/repos/davidx/prtester/{archive_format}{/ref}
+      downloads_url: https://api.github.com/repos/davidx/prtester/downloads
+      issues_url: https://api.github.com/repos/davidx/prtester/issues{/number}
+      pulls_url: https://api.github.com/repos/davidx/prtester/pulls{/number}
+      milestones_url: https://api.github.com/repos/davidx/prtester/milestones{/number}
+      notifications_url: https://api.github.com/repos/davidx/prtester/notifications{?since,all,participating}
+      labels_url: https://api.github.com/repos/davidx/prtester/labels{/name}
+      releases_url: https://api.github.com/repos/davidx/prtester/releases{/id}
+      deployments_url: https://api.github.com/repos/davidx/prtester/deployments
+      created_at: '2016-08-05T07:21:52Z'
+      updated_at: '2016-08-05T07:29:52Z'
+      pushed_at: '2016-10-31T20:56:55Z'
+      git_url: git://github.com/davidx/prtester.git
+      ssh_url: git@github.com:davidx/prtester.git
+      clone_url: https://github.com/davidx/prtester.git
+      svn_url: https://github.com/davidx/prtester
+      homepage:
+      size: 287
+      stargazers_count: 0
+      watchers_count: 0
+      language: Makefile
+      has_issues: true
+      has_downloads: true
+      has_wiki: true
+      has_pages: false
+      forks_count: 2
+      mirror_url:
+      open_issues_count: 3
+      forks: 2
+      open_issues: 3
+      watchers: 0
+      default_branch: master
+  base:
+    label: davidx:master
+    ref: master
+    sha: ad286051e1fc0fd8f3297008ab29faa934203c67
+    user:
+      login: davidx
+      id: 17162
+      avatar_url: https://avatars.githubusercontent.com/u/17162?v=3
+      gravatar_id: ''
+      url: https://api.github.com/users/davidx
+      html_url: https://github.com/davidx
+      followers_url: https://api.github.com/users/davidx/followers
+      following_url: https://api.github.com/users/davidx/following{/other_user}
+      gists_url: https://api.github.com/users/davidx/gists{/gist_id}
+      starred_url: https://api.github.com/users/davidx/starred{/owner}{/repo}
+      subscriptions_url: https://api.github.com/users/davidx/subscriptions
+      organizations_url: https://api.github.com/users/davidx/orgs
+      repos_url: https://api.github.com/users/davidx/repos
+      events_url: https://api.github.com/users/davidx/events{/privacy}
+      received_events_url: https://api.github.com/users/davidx/received_events
+      type: User
+      site_admin: false
+    repo:
+      id: 64998050
+      name: prtester
+      full_name: davidx/prtester
+      owner:
+        login: davidx
+        id: 17162
+        avatar_url: https://avatars.githubusercontent.com/u/17162?v=3
+        gravatar_id: ''
+        url: https://api.github.com/users/davidx
+        html_url: https://github.com/davidx
+        followers_url: https://api.github.com/users/davidx/followers
+        following_url: https://api.github.com/users/davidx/following{/other_user}
+        gists_url: https://api.github.com/users/davidx/gists{/gist_id}
+        starred_url: https://api.github.com/users/davidx/starred{/owner}{/repo}
+        subscriptions_url: https://api.github.com/users/davidx/subscriptions
+        organizations_url: https://api.github.com/users/davidx/orgs
+        repos_url: https://api.github.com/users/davidx/repos
+        events_url: https://api.github.com/users/davidx/events{/privacy}
+        received_events_url: https://api.github.com/users/davidx/received_events
+        type: User
+        site_admin: false
+      private: false
+      html_url: https://github.com/davidx/prtester
+      description: testing pr
+      fork: false
+      url: https://api.github.com/repos/davidx/prtester
+      forks_url: https://api.github.com/repos/davidx/prtester/forks
+      keys_url: https://api.github.com/repos/davidx/prtester/keys{/key_id}
+      collaborators_url: https://api.github.com/repos/davidx/prtester/collaborators{/collaborator}
+      teams_url: https://api.github.com/repos/davidx/prtester/teams
+      hooks_url: https://api.github.com/repos/davidx/prtester/hooks
+      issue_events_url: https://api.github.com/repos/davidx/prtester/issues/events{/number}
+      events_url: https://api.github.com/repos/davidx/prtester/events
+      assignees_url: https://api.github.com/repos/davidx/prtester/assignees{/user}
+      branches_url: https://api.github.com/repos/davidx/prtester/branches{/branch}
+      tags_url: https://api.github.com/repos/davidx/prtester/tags
+      blobs_url: https://api.github.com/repos/davidx/prtester/git/blobs{/sha}
+      git_tags_url: https://api.github.com/repos/davidx/prtester/git/tags{/sha}
+      git_refs_url: https://api.github.com/repos/davidx/prtester/git/refs{/sha}
+      trees_url: https://api.github.com/repos/davidx/prtester/git/trees{/sha}
+      statuses_url: https://api.github.com/repos/davidx/prtester/statuses/{sha}
+      languages_url: https://api.github.com/repos/davidx/prtester/languages
+      stargazers_url: https://api.github.com/repos/davidx/prtester/stargazers
+      contributors_url: https://api.github.com/repos/davidx/prtester/contributors
+      subscribers_url: https://api.github.com/repos/davidx/prtester/subscribers
+      subscription_url: https://api.github.com/repos/davidx/prtester/subscription
+      commits_url: https://api.github.com/repos/davidx/prtester/commits{/sha}
+      git_commits_url: https://api.github.com/repos/davidx/prtester/git/commits{/sha}
+      comments_url: https://api.github.com/repos/davidx/prtester/comments{/number}
+      issue_comment_url: https://api.github.com/repos/davidx/prtester/issues/comments{/number}
+      contents_url: https://api.github.com/repos/davidx/prtester/contents/{+path}
+      compare_url: https://api.github.com/repos/davidx/prtester/compare/{base}...{head}
+      merges_url: https://api.github.com/repos/davidx/prtester/merges
+      archive_url: https://api.github.com/repos/davidx/prtester/{archive_format}{/ref}
+      downloads_url: https://api.github.com/repos/davidx/prtester/downloads
+      issues_url: https://api.github.com/repos/davidx/prtester/issues{/number}
+      pulls_url: https://api.github.com/repos/davidx/prtester/pulls{/number}
+      milestones_url: https://api.github.com/repos/davidx/prtester/milestones{/number}
+      notifications_url: https://api.github.com/repos/davidx/prtester/notifications{?since,all,participating}
+      labels_url: https://api.github.com/repos/davidx/prtester/labels{/name}
+      releases_url: https://api.github.com/repos/davidx/prtester/releases{/id}
+      deployments_url: https://api.github.com/repos/davidx/prtester/deployments
+      created_at: '2016-08-05T07:21:52Z'
+      updated_at: '2016-08-05T07:29:52Z'
+      pushed_at: '2016-10-31T20:56:55Z'
+      git_url: git://github.com/davidx/prtester.git
+      ssh_url: git@github.com:davidx/prtester.git
+      clone_url: https://github.com/davidx/prtester.git
+      svn_url: https://github.com/davidx/prtester
+      homepage:
+      size: 287
+      stargazers_count: 0
+      watchers_count: 0
+      language: Makefile
+      has_issues: true
+      has_downloads: true
+      has_wiki: true
+      has_pages: false
+      forks_count: 2
+      mirror_url:
+      open_issues_count: 3
+      forks: 2
+      open_issues: 3
+      watchers: 0
+      default_branch: master
+  _links:
+    self:
+      href: https://api.github.com/repos/davidx/prtester/pulls/296
+    html:
+      href: https://github.com/davidx/prtester/pull/296
+    issue:
+      href: https://api.github.com/repos/davidx/prtester/issues/296
+    comments:
+      href: https://api.github.com/repos/davidx/prtester/issues/296/comments
+    review_comments:
+      href: https://api.github.com/repos/davidx/prtester/pulls/296/comments
+    review_comment:
+      href: https://api.github.com/repos/davidx/prtester/pulls/comments{/number}
+    commits:
+      href: https://api.github.com/repos/davidx/prtester/pulls/296/commits
+    statuses:
+      href: https://api.github.com/repos/davidx/prtester/statuses/11a41e96587c46e4e8da4e1a4b094b29ef7282a3
+repository:
+  id: 64998050
+  name: prtester
+  full_name: davidx/prtester
+  owner:
+    login: davidx
+    id: 17162
+    avatar_url: https://avatars.githubusercontent.com/u/17162?v=3
+    gravatar_id: ''
+    url: https://api.github.com/users/davidx
+    html_url: https://github.com/davidx
+    followers_url: https://api.github.com/users/davidx/followers
+    following_url: https://api.github.com/users/davidx/following{/other_user}
+    gists_url: https://api.github.com/users/davidx/gists{/gist_id}
+    starred_url: https://api.github.com/users/davidx/starred{/owner}{/repo}
+    subscriptions_url: https://api.github.com/users/davidx/subscriptions
+    organizations_url: https://api.github.com/users/davidx/orgs
+    repos_url: https://api.github.com/users/davidx/repos
+    events_url: https://api.github.com/users/davidx/events{/privacy}
+    received_events_url: https://api.github.com/users/davidx/received_events
+    type: User
+    site_admin: false
+  private: false
+  html_url: https://github.com/davidx/prtester
+  description: testing pr
+  fork: false
+  url: https://api.github.com/repos/davidx/prtester
+  forks_url: https://api.github.com/repos/davidx/prtester/forks
+  keys_url: https://api.github.com/repos/davidx/prtester/keys{/key_id}
+  collaborators_url: https://api.github.com/repos/davidx/prtester/collaborators{/collaborator}
+  teams_url: https://api.github.com/repos/davidx/prtester/teams
+  hooks_url: https://api.github.com/repos/davidx/prtester/hooks
+  issue_events_url: https://api.github.com/repos/davidx/prtester/issues/events{/number}
+  events_url: https://api.github.com/repos/davidx/prtester/events
+  assignees_url: https://api.github.com/repos/davidx/prtester/assignees{/user}
+  branches_url: https://api.github.com/repos/davidx/prtester/branches{/branch}
+  tags_url: https://api.github.com/repos/davidx/prtester/tags
+  blobs_url: https://api.github.com/repos/davidx/prtester/git/blobs{/sha}
+  git_tags_url: https://api.github.com/repos/davidx/prtester/git/tags{/sha}
+  git_refs_url: https://api.github.com/repos/davidx/prtester/git/refs{/sha}
+  trees_url: https://api.github.com/repos/davidx/prtester/git/trees{/sha}
+  statuses_url: https://api.github.com/repos/davidx/prtester/statuses/{sha}
+  languages_url: https://api.github.com/repos/davidx/prtester/languages
+  stargazers_url: https://api.github.com/repos/davidx/prtester/stargazers
+  contributors_url: https://api.github.com/repos/davidx/prtester/contributors
+  subscribers_url: https://api.github.com/repos/davidx/prtester/subscribers
+  subscription_url: https://api.github.com/repos/davidx/prtester/subscription
+  commits_url: https://api.github.com/repos/davidx/prtester/commits{/sha}
+  git_commits_url: https://api.github.com/repos/davidx/prtester/git/commits{/sha}
+  comments_url: https://api.github.com/repos/davidx/prtester/comments{/number}
+  issue_comment_url: https://api.github.com/repos/davidx/prtester/issues/comments{/number}
+  contents_url: https://api.github.com/repos/davidx/prtester/contents/{+path}
+  compare_url: https://api.github.com/repos/davidx/prtester/compare/{base}...{head}
+  merges_url: https://api.github.com/repos/davidx/prtester/merges
+  archive_url: https://api.github.com/repos/davidx/prtester/{archive_format}{/ref}
+  downloads_url: https://api.github.com/repos/davidx/prtester/downloads
+  issues_url: https://api.github.com/repos/davidx/prtester/issues{/number}
+  pulls_url: https://api.github.com/repos/davidx/prtester/pulls{/number}
+  milestones_url: https://api.github.com/repos/davidx/prtester/milestones{/number}
+  notifications_url: https://api.github.com/repos/davidx/prtester/notifications{?since,all,participating}
+  labels_url: https://api.github.com/repos/davidx/prtester/labels{/name}
+  releases_url: https://api.github.com/repos/davidx/prtester/releases{/id}
+  deployments_url: https://api.github.com/repos/davidx/prtester/deployments
+  created_at: '2016-08-05T07:21:52Z'
+  updated_at: '2016-08-05T07:29:52Z'
+  pushed_at: '2016-10-31T20:56:55Z'
+  git_url: git://github.com/davidx/prtester.git
+  ssh_url: git@github.com:davidx/prtester.git
+  clone_url: https://github.com/davidx/prtester.git
+  svn_url: https://github.com/davidx/prtester
+  homepage:
+  size: 287
+  stargazers_count: 0
+  watchers_count: 0
+  language: Makefile
+  has_issues: true
+  has_downloads: true
+  has_wiki: true
+  has_pages: false
+  forks_count: 2
+  mirror_url:
+  open_issues_count: 3
+  forks: 2
+  open_issues: 3
+  watchers: 0
+  default_branch: master
+sender:
+  login: davidpuddy1
+  id: 20779719
+  avatar_url: https://avatars.githubusercontent.com/u/20779719?v=3
+  gravatar_id: ''
+  url: https://api.github.com/users/davidpuddy1
+  html_url: https://github.com/davidpuddy1
+  followers_url: https://api.github.com/users/davidpuddy1/followers
+  following_url: https://api.github.com/users/davidpuddy1/following{/other_user}
+  gists_url: https://api.github.com/users/davidpuddy1/gists{/gist_id}
+  starred_url: https://api.github.com/users/davidpuddy1/starred{/owner}{/repo}
+  subscriptions_url: https://api.github.com/users/davidpuddy1/subscriptions
+  organizations_url: https://api.github.com/users/davidpuddy1/orgs
+  repos_url: https://api.github.com/users/davidpuddy1/repos
+  events_url: https://api.github.com/users/davidpuddy1/events{/privacy}
+  received_events_url: https://api.github.com/users/davidpuddy1/received_events
+  type: User
+  site_admin: false

--- a/test/fixtures/code_comment.yml
+++ b/test/fixtures/code_comment.yml
@@ -1,0 +1,412 @@
+---
+action: submitted
+review:
+  id: 6525579
+  user:
+    login: davidpuddy1
+    id: 20779719
+    avatar_url: https://avatars.githubusercontent.com/u/20779719?v=3
+    gravatar_id: ''
+    url: https://api.github.com/users/davidpuddy1
+    html_url: https://github.com/davidpuddy1
+    followers_url: https://api.github.com/users/davidpuddy1/followers
+    following_url: https://api.github.com/users/davidpuddy1/following{/other_user}
+    gists_url: https://api.github.com/users/davidpuddy1/gists{/gist_id}
+    starred_url: https://api.github.com/users/davidpuddy1/starred{/owner}{/repo}
+    subscriptions_url: https://api.github.com/users/davidpuddy1/subscriptions
+    organizations_url: https://api.github.com/users/davidpuddy1/orgs
+    repos_url: https://api.github.com/users/davidpuddy1/repos
+    events_url: https://api.github.com/users/davidpuddy1/events{/privacy}
+    received_events_url: https://api.github.com/users/davidpuddy1/received_events
+    type: User
+    site_admin: false
+  body: this is interesting yet not merge worthy
+  submitted_at: '2016-10-31T21:06:59Z'
+  state: commented
+  html_url: https://github.com/davidx/prtester/pull/296#pullrequestreview-6525579
+  pull_request_url: https://api.github.com/repos/davidx/prtester/pulls/296
+  _links:
+    html:
+      href: https://github.com/davidx/prtester/pull/296#pullrequestreview-6525579
+    pull_request:
+      href: https://api.github.com/repos/davidx/prtester/pulls/296
+pull_request:
+  url: https://api.github.com/repos/davidx/prtester/pulls/296
+  id: 91689123
+  html_url: https://github.com/davidx/prtester/pull/296
+  diff_url: https://github.com/davidx/prtester/pull/296.diff
+  patch_url: https://github.com/davidx/prtester/pull/296.patch
+  issue_url: https://api.github.com/repos/davidx/prtester/issues/296
+  number: 296
+  state: open
+  locked: false
+  title: tester
+  user:
+    login: davidx
+    id: 17162
+    avatar_url: https://avatars.githubusercontent.com/u/17162?v=3
+    gravatar_id: ''
+    url: https://api.github.com/users/davidx
+    html_url: https://github.com/davidx
+    followers_url: https://api.github.com/users/davidx/followers
+    following_url: https://api.github.com/users/davidx/following{/other_user}
+    gists_url: https://api.github.com/users/davidx/gists{/gist_id}
+    starred_url: https://api.github.com/users/davidx/starred{/owner}{/repo}
+    subscriptions_url: https://api.github.com/users/davidx/subscriptions
+    organizations_url: https://api.github.com/users/davidx/orgs
+    repos_url: https://api.github.com/users/davidx/repos
+    events_url: https://api.github.com/users/davidx/events{/privacy}
+    received_events_url: https://api.github.com/users/davidx/received_events
+    type: User
+    site_admin: false
+  body: ''
+  created_at: '2016-10-31T20:56:55Z'
+  updated_at: '2016-10-31T21:06:59Z'
+  closed_at:
+  merged_at:
+  merge_commit_sha: 43fd70d0086a81e01e0381bc5cbddb1c22e19aac
+  assignee:
+  assignees: []
+  milestone:
+  commits_url: https://api.github.com/repos/davidx/prtester/pulls/296/commits
+  review_comments_url: https://api.github.com/repos/davidx/prtester/pulls/296/comments
+  review_comment_url: https://api.github.com/repos/davidx/prtester/pulls/comments{/number}
+  comments_url: https://api.github.com/repos/davidx/prtester/issues/296/comments
+  statuses_url: https://api.github.com/repos/davidx/prtester/statuses/5ab810d9cde984eddd5f66051192aa8fc3bec1cf
+  head:
+    label: davidx:1477931168
+    ref: '1477931168'
+    sha: 5ab810d9cde984eddd5f66051192aa8fc3bec1cf
+    user:
+      login: davidx
+      id: 17162
+      avatar_url: https://avatars.githubusercontent.com/u/17162?v=3
+      gravatar_id: ''
+      url: https://api.github.com/users/davidx
+      html_url: https://github.com/davidx
+      followers_url: https://api.github.com/users/davidx/followers
+      following_url: https://api.github.com/users/davidx/following{/other_user}
+      gists_url: https://api.github.com/users/davidx/gists{/gist_id}
+      starred_url: https://api.github.com/users/davidx/starred{/owner}{/repo}
+      subscriptions_url: https://api.github.com/users/davidx/subscriptions
+      organizations_url: https://api.github.com/users/davidx/orgs
+      repos_url: https://api.github.com/users/davidx/repos
+      events_url: https://api.github.com/users/davidx/events{/privacy}
+      received_events_url: https://api.github.com/users/davidx/received_events
+      type: User
+      site_admin: false
+    repo:
+      id: 64998050
+      name: prtester
+      full_name: davidx/prtester
+      owner:
+        login: davidx
+        id: 17162
+        avatar_url: https://avatars.githubusercontent.com/u/17162?v=3
+        gravatar_id: ''
+        url: https://api.github.com/users/davidx
+        html_url: https://github.com/davidx
+        followers_url: https://api.github.com/users/davidx/followers
+        following_url: https://api.github.com/users/davidx/following{/other_user}
+        gists_url: https://api.github.com/users/davidx/gists{/gist_id}
+        starred_url: https://api.github.com/users/davidx/starred{/owner}{/repo}
+        subscriptions_url: https://api.github.com/users/davidx/subscriptions
+        organizations_url: https://api.github.com/users/davidx/orgs
+        repos_url: https://api.github.com/users/davidx/repos
+        events_url: https://api.github.com/users/davidx/events{/privacy}
+        received_events_url: https://api.github.com/users/davidx/received_events
+        type: User
+        site_admin: false
+      private: false
+      html_url: https://github.com/davidx/prtester
+      description: testing pr
+      fork: false
+      url: https://api.github.com/repos/davidx/prtester
+      forks_url: https://api.github.com/repos/davidx/prtester/forks
+      keys_url: https://api.github.com/repos/davidx/prtester/keys{/key_id}
+      collaborators_url: https://api.github.com/repos/davidx/prtester/collaborators{/collaborator}
+      teams_url: https://api.github.com/repos/davidx/prtester/teams
+      hooks_url: https://api.github.com/repos/davidx/prtester/hooks
+      issue_events_url: https://api.github.com/repos/davidx/prtester/issues/events{/number}
+      events_url: https://api.github.com/repos/davidx/prtester/events
+      assignees_url: https://api.github.com/repos/davidx/prtester/assignees{/user}
+      branches_url: https://api.github.com/repos/davidx/prtester/branches{/branch}
+      tags_url: https://api.github.com/repos/davidx/prtester/tags
+      blobs_url: https://api.github.com/repos/davidx/prtester/git/blobs{/sha}
+      git_tags_url: https://api.github.com/repos/davidx/prtester/git/tags{/sha}
+      git_refs_url: https://api.github.com/repos/davidx/prtester/git/refs{/sha}
+      trees_url: https://api.github.com/repos/davidx/prtester/git/trees{/sha}
+      statuses_url: https://api.github.com/repos/davidx/prtester/statuses/{sha}
+      languages_url: https://api.github.com/repos/davidx/prtester/languages
+      stargazers_url: https://api.github.com/repos/davidx/prtester/stargazers
+      contributors_url: https://api.github.com/repos/davidx/prtester/contributors
+      subscribers_url: https://api.github.com/repos/davidx/prtester/subscribers
+      subscription_url: https://api.github.com/repos/davidx/prtester/subscription
+      commits_url: https://api.github.com/repos/davidx/prtester/commits{/sha}
+      git_commits_url: https://api.github.com/repos/davidx/prtester/git/commits{/sha}
+      comments_url: https://api.github.com/repos/davidx/prtester/comments{/number}
+      issue_comment_url: https://api.github.com/repos/davidx/prtester/issues/comments{/number}
+      contents_url: https://api.github.com/repos/davidx/prtester/contents/{+path}
+      compare_url: https://api.github.com/repos/davidx/prtester/compare/{base}...{head}
+      merges_url: https://api.github.com/repos/davidx/prtester/merges
+      archive_url: https://api.github.com/repos/davidx/prtester/{archive_format}{/ref}
+      downloads_url: https://api.github.com/repos/davidx/prtester/downloads
+      issues_url: https://api.github.com/repos/davidx/prtester/issues{/number}
+      pulls_url: https://api.github.com/repos/davidx/prtester/pulls{/number}
+      milestones_url: https://api.github.com/repos/davidx/prtester/milestones{/number}
+      notifications_url: https://api.github.com/repos/davidx/prtester/notifications{?since,all,participating}
+      labels_url: https://api.github.com/repos/davidx/prtester/labels{/name}
+      releases_url: https://api.github.com/repos/davidx/prtester/releases{/id}
+      deployments_url: https://api.github.com/repos/davidx/prtester/deployments
+      created_at: '2016-08-05T07:21:52Z'
+      updated_at: '2016-08-05T07:29:52Z'
+      pushed_at: '2016-10-31T21:04:57Z'
+      git_url: git://github.com/davidx/prtester.git
+      ssh_url: git@github.com:davidx/prtester.git
+      clone_url: https://github.com/davidx/prtester.git
+      svn_url: https://github.com/davidx/prtester
+      homepage:
+      size: 287
+      stargazers_count: 0
+      watchers_count: 0
+      language: Makefile
+      has_issues: true
+      has_downloads: true
+      has_wiki: true
+      has_pages: false
+      forks_count: 2
+      mirror_url:
+      open_issues_count: 3
+      forks: 2
+      open_issues: 3
+      watchers: 0
+      default_branch: master
+  base:
+    label: davidx:master
+    ref: master
+    sha: ad286051e1fc0fd8f3297008ab29faa934203c67
+    user:
+      login: davidx
+      id: 17162
+      avatar_url: https://avatars.githubusercontent.com/u/17162?v=3
+      gravatar_id: ''
+      url: https://api.github.com/users/davidx
+      html_url: https://github.com/davidx
+      followers_url: https://api.github.com/users/davidx/followers
+      following_url: https://api.github.com/users/davidx/following{/other_user}
+      gists_url: https://api.github.com/users/davidx/gists{/gist_id}
+      starred_url: https://api.github.com/users/davidx/starred{/owner}{/repo}
+      subscriptions_url: https://api.github.com/users/davidx/subscriptions
+      organizations_url: https://api.github.com/users/davidx/orgs
+      repos_url: https://api.github.com/users/davidx/repos
+      events_url: https://api.github.com/users/davidx/events{/privacy}
+      received_events_url: https://api.github.com/users/davidx/received_events
+      type: User
+      site_admin: false
+    repo:
+      id: 64998050
+      name: prtester
+      full_name: davidx/prtester
+      owner:
+        login: davidx
+        id: 17162
+        avatar_url: https://avatars.githubusercontent.com/u/17162?v=3
+        gravatar_id: ''
+        url: https://api.github.com/users/davidx
+        html_url: https://github.com/davidx
+        followers_url: https://api.github.com/users/davidx/followers
+        following_url: https://api.github.com/users/davidx/following{/other_user}
+        gists_url: https://api.github.com/users/davidx/gists{/gist_id}
+        starred_url: https://api.github.com/users/davidx/starred{/owner}{/repo}
+        subscriptions_url: https://api.github.com/users/davidx/subscriptions
+        organizations_url: https://api.github.com/users/davidx/orgs
+        repos_url: https://api.github.com/users/davidx/repos
+        events_url: https://api.github.com/users/davidx/events{/privacy}
+        received_events_url: https://api.github.com/users/davidx/received_events
+        type: User
+        site_admin: false
+      private: false
+      html_url: https://github.com/davidx/prtester
+      description: testing pr
+      fork: false
+      url: https://api.github.com/repos/davidx/prtester
+      forks_url: https://api.github.com/repos/davidx/prtester/forks
+      keys_url: https://api.github.com/repos/davidx/prtester/keys{/key_id}
+      collaborators_url: https://api.github.com/repos/davidx/prtester/collaborators{/collaborator}
+      teams_url: https://api.github.com/repos/davidx/prtester/teams
+      hooks_url: https://api.github.com/repos/davidx/prtester/hooks
+      issue_events_url: https://api.github.com/repos/davidx/prtester/issues/events{/number}
+      events_url: https://api.github.com/repos/davidx/prtester/events
+      assignees_url: https://api.github.com/repos/davidx/prtester/assignees{/user}
+      branches_url: https://api.github.com/repos/davidx/prtester/branches{/branch}
+      tags_url: https://api.github.com/repos/davidx/prtester/tags
+      blobs_url: https://api.github.com/repos/davidx/prtester/git/blobs{/sha}
+      git_tags_url: https://api.github.com/repos/davidx/prtester/git/tags{/sha}
+      git_refs_url: https://api.github.com/repos/davidx/prtester/git/refs{/sha}
+      trees_url: https://api.github.com/repos/davidx/prtester/git/trees{/sha}
+      statuses_url: https://api.github.com/repos/davidx/prtester/statuses/{sha}
+      languages_url: https://api.github.com/repos/davidx/prtester/languages
+      stargazers_url: https://api.github.com/repos/davidx/prtester/stargazers
+      contributors_url: https://api.github.com/repos/davidx/prtester/contributors
+      subscribers_url: https://api.github.com/repos/davidx/prtester/subscribers
+      subscription_url: https://api.github.com/repos/davidx/prtester/subscription
+      commits_url: https://api.github.com/repos/davidx/prtester/commits{/sha}
+      git_commits_url: https://api.github.com/repos/davidx/prtester/git/commits{/sha}
+      comments_url: https://api.github.com/repos/davidx/prtester/comments{/number}
+      issue_comment_url: https://api.github.com/repos/davidx/prtester/issues/comments{/number}
+      contents_url: https://api.github.com/repos/davidx/prtester/contents/{+path}
+      compare_url: https://api.github.com/repos/davidx/prtester/compare/{base}...{head}
+      merges_url: https://api.github.com/repos/davidx/prtester/merges
+      archive_url: https://api.github.com/repos/davidx/prtester/{archive_format}{/ref}
+      downloads_url: https://api.github.com/repos/davidx/prtester/downloads
+      issues_url: https://api.github.com/repos/davidx/prtester/issues{/number}
+      pulls_url: https://api.github.com/repos/davidx/prtester/pulls{/number}
+      milestones_url: https://api.github.com/repos/davidx/prtester/milestones{/number}
+      notifications_url: https://api.github.com/repos/davidx/prtester/notifications{?since,all,participating}
+      labels_url: https://api.github.com/repos/davidx/prtester/labels{/name}
+      releases_url: https://api.github.com/repos/davidx/prtester/releases{/id}
+      deployments_url: https://api.github.com/repos/davidx/prtester/deployments
+      created_at: '2016-08-05T07:21:52Z'
+      updated_at: '2016-08-05T07:29:52Z'
+      pushed_at: '2016-10-31T21:04:57Z'
+      git_url: git://github.com/davidx/prtester.git
+      ssh_url: git@github.com:davidx/prtester.git
+      clone_url: https://github.com/davidx/prtester.git
+      svn_url: https://github.com/davidx/prtester
+      homepage:
+      size: 287
+      stargazers_count: 0
+      watchers_count: 0
+      language: Makefile
+      has_issues: true
+      has_downloads: true
+      has_wiki: true
+      has_pages: false
+      forks_count: 2
+      mirror_url:
+      open_issues_count: 3
+      forks: 2
+      open_issues: 3
+      watchers: 0
+      default_branch: master
+  _links:
+    self:
+      href: https://api.github.com/repos/davidx/prtester/pulls/296
+    html:
+      href: https://github.com/davidx/prtester/pull/296
+    issue:
+      href: https://api.github.com/repos/davidx/prtester/issues/296
+    comments:
+      href: https://api.github.com/repos/davidx/prtester/issues/296/comments
+    review_comments:
+      href: https://api.github.com/repos/davidx/prtester/pulls/296/comments
+    review_comment:
+      href: https://api.github.com/repos/davidx/prtester/pulls/comments{/number}
+    commits:
+      href: https://api.github.com/repos/davidx/prtester/pulls/296/commits
+    statuses:
+      href: https://api.github.com/repos/davidx/prtester/statuses/5ab810d9cde984eddd5f66051192aa8fc3bec1cf
+repository:
+  id: 64998050
+  name: prtester
+  full_name: davidx/prtester
+  owner:
+    login: davidx
+    id: 17162
+    avatar_url: https://avatars.githubusercontent.com/u/17162?v=3
+    gravatar_id: ''
+    url: https://api.github.com/users/davidx
+    html_url: https://github.com/davidx
+    followers_url: https://api.github.com/users/davidx/followers
+    following_url: https://api.github.com/users/davidx/following{/other_user}
+    gists_url: https://api.github.com/users/davidx/gists{/gist_id}
+    starred_url: https://api.github.com/users/davidx/starred{/owner}{/repo}
+    subscriptions_url: https://api.github.com/users/davidx/subscriptions
+    organizations_url: https://api.github.com/users/davidx/orgs
+    repos_url: https://api.github.com/users/davidx/repos
+    events_url: https://api.github.com/users/davidx/events{/privacy}
+    received_events_url: https://api.github.com/users/davidx/received_events
+    type: User
+    site_admin: false
+  private: false
+  html_url: https://github.com/davidx/prtester
+  description: testing pr
+  fork: false
+  url: https://api.github.com/repos/davidx/prtester
+  forks_url: https://api.github.com/repos/davidx/prtester/forks
+  keys_url: https://api.github.com/repos/davidx/prtester/keys{/key_id}
+  collaborators_url: https://api.github.com/repos/davidx/prtester/collaborators{/collaborator}
+  teams_url: https://api.github.com/repos/davidx/prtester/teams
+  hooks_url: https://api.github.com/repos/davidx/prtester/hooks
+  issue_events_url: https://api.github.com/repos/davidx/prtester/issues/events{/number}
+  events_url: https://api.github.com/repos/davidx/prtester/events
+  assignees_url: https://api.github.com/repos/davidx/prtester/assignees{/user}
+  branches_url: https://api.github.com/repos/davidx/prtester/branches{/branch}
+  tags_url: https://api.github.com/repos/davidx/prtester/tags
+  blobs_url: https://api.github.com/repos/davidx/prtester/git/blobs{/sha}
+  git_tags_url: https://api.github.com/repos/davidx/prtester/git/tags{/sha}
+  git_refs_url: https://api.github.com/repos/davidx/prtester/git/refs{/sha}
+  trees_url: https://api.github.com/repos/davidx/prtester/git/trees{/sha}
+  statuses_url: https://api.github.com/repos/davidx/prtester/statuses/{sha}
+  languages_url: https://api.github.com/repos/davidx/prtester/languages
+  stargazers_url: https://api.github.com/repos/davidx/prtester/stargazers
+  contributors_url: https://api.github.com/repos/davidx/prtester/contributors
+  subscribers_url: https://api.github.com/repos/davidx/prtester/subscribers
+  subscription_url: https://api.github.com/repos/davidx/prtester/subscription
+  commits_url: https://api.github.com/repos/davidx/prtester/commits{/sha}
+  git_commits_url: https://api.github.com/repos/davidx/prtester/git/commits{/sha}
+  comments_url: https://api.github.com/repos/davidx/prtester/comments{/number}
+  issue_comment_url: https://api.github.com/repos/davidx/prtester/issues/comments{/number}
+  contents_url: https://api.github.com/repos/davidx/prtester/contents/{+path}
+  compare_url: https://api.github.com/repos/davidx/prtester/compare/{base}...{head}
+  merges_url: https://api.github.com/repos/davidx/prtester/merges
+  archive_url: https://api.github.com/repos/davidx/prtester/{archive_format}{/ref}
+  downloads_url: https://api.github.com/repos/davidx/prtester/downloads
+  issues_url: https://api.github.com/repos/davidx/prtester/issues{/number}
+  pulls_url: https://api.github.com/repos/davidx/prtester/pulls{/number}
+  milestones_url: https://api.github.com/repos/davidx/prtester/milestones{/number}
+  notifications_url: https://api.github.com/repos/davidx/prtester/notifications{?since,all,participating}
+  labels_url: https://api.github.com/repos/davidx/prtester/labels{/name}
+  releases_url: https://api.github.com/repos/davidx/prtester/releases{/id}
+  deployments_url: https://api.github.com/repos/davidx/prtester/deployments
+  created_at: '2016-08-05T07:21:52Z'
+  updated_at: '2016-08-05T07:29:52Z'
+  pushed_at: '2016-10-31T21:04:57Z'
+  git_url: git://github.com/davidx/prtester.git
+  ssh_url: git@github.com:davidx/prtester.git
+  clone_url: https://github.com/davidx/prtester.git
+  svn_url: https://github.com/davidx/prtester
+  homepage:
+  size: 287
+  stargazers_count: 0
+  watchers_count: 0
+  language: Makefile
+  has_issues: true
+  has_downloads: true
+  has_wiki: true
+  has_pages: false
+  forks_count: 2
+  mirror_url:
+  open_issues_count: 3
+  forks: 2
+  open_issues: 3
+  watchers: 0
+  default_branch: master
+sender:
+  login: davidpuddy1
+  id: 20779719
+  avatar_url: https://avatars.githubusercontent.com/u/20779719?v=3
+  gravatar_id: ''
+  url: https://api.github.com/users/davidpuddy1
+  html_url: https://github.com/davidpuddy1
+  followers_url: https://api.github.com/users/davidpuddy1/followers
+  following_url: https://api.github.com/users/davidpuddy1/following{/other_user}
+  gists_url: https://api.github.com/users/davidpuddy1/gists{/gist_id}
+  starred_url: https://api.github.com/users/davidpuddy1/starred{/owner}{/repo}
+  subscriptions_url: https://api.github.com/users/davidpuddy1/subscriptions
+  organizations_url: https://api.github.com/users/davidpuddy1/orgs
+  repos_url: https://api.github.com/users/davidpuddy1/repos
+  events_url: https://api.github.com/users/davidpuddy1/events{/privacy}
+  received_events_url: https://api.github.com/users/davidpuddy1/received_events
+  type: User
+  site_admin: false

--- a/test/fixtures/request_changes.yml
+++ b/test/fixtures/request_changes.yml
@@ -1,0 +1,412 @@
+---
+action: submitted
+review:
+  id: 6525978
+  user:
+    login: davidpuddy1
+    id: 20779719
+    avatar_url: https://avatars.githubusercontent.com/u/20779719?v=3
+    gravatar_id: ''
+    url: https://api.github.com/users/davidpuddy1
+    html_url: https://github.com/davidpuddy1
+    followers_url: https://api.github.com/users/davidpuddy1/followers
+    following_url: https://api.github.com/users/davidpuddy1/following{/other_user}
+    gists_url: https://api.github.com/users/davidpuddy1/gists{/gist_id}
+    starred_url: https://api.github.com/users/davidpuddy1/starred{/owner}{/repo}
+    subscriptions_url: https://api.github.com/users/davidpuddy1/subscriptions
+    organizations_url: https://api.github.com/users/davidpuddy1/orgs
+    repos_url: https://api.github.com/users/davidpuddy1/repos
+    events_url: https://api.github.com/users/davidpuddy1/events{/privacy}
+    received_events_url: https://api.github.com/users/davidpuddy1/received_events
+    type: User
+    site_admin: false
+  body: tester
+  submitted_at: '2016-10-31T21:08:35Z'
+  state: changes_requested
+  html_url: https://github.com/davidx/prtester/pull/296#pullrequestreview-6525978
+  pull_request_url: https://api.github.com/repos/davidx/prtester/pulls/296
+  _links:
+    html:
+      href: https://github.com/davidx/prtester/pull/296#pullrequestreview-6525978
+    pull_request:
+      href: https://api.github.com/repos/davidx/prtester/pulls/296
+pull_request:
+  url: https://api.github.com/repos/davidx/prtester/pulls/296
+  id: 91689123
+  html_url: https://github.com/davidx/prtester/pull/296
+  diff_url: https://github.com/davidx/prtester/pull/296.diff
+  patch_url: https://github.com/davidx/prtester/pull/296.patch
+  issue_url: https://api.github.com/repos/davidx/prtester/issues/296
+  number: 296
+  state: open
+  locked: false
+  title: tester
+  user:
+    login: davidx
+    id: 17162
+    avatar_url: https://avatars.githubusercontent.com/u/17162?v=3
+    gravatar_id: ''
+    url: https://api.github.com/users/davidx
+    html_url: https://github.com/davidx
+    followers_url: https://api.github.com/users/davidx/followers
+    following_url: https://api.github.com/users/davidx/following{/other_user}
+    gists_url: https://api.github.com/users/davidx/gists{/gist_id}
+    starred_url: https://api.github.com/users/davidx/starred{/owner}{/repo}
+    subscriptions_url: https://api.github.com/users/davidx/subscriptions
+    organizations_url: https://api.github.com/users/davidx/orgs
+    repos_url: https://api.github.com/users/davidx/repos
+    events_url: https://api.github.com/users/davidx/events{/privacy}
+    received_events_url: https://api.github.com/users/davidx/received_events
+    type: User
+    site_admin: false
+  body: ''
+  created_at: '2016-10-31T20:56:55Z'
+  updated_at: '2016-10-31T21:08:35Z'
+  closed_at:
+  merged_at:
+  merge_commit_sha: 43fd70d0086a81e01e0381bc5cbddb1c22e19aac
+  assignee:
+  assignees: []
+  milestone:
+  commits_url: https://api.github.com/repos/davidx/prtester/pulls/296/commits
+  review_comments_url: https://api.github.com/repos/davidx/prtester/pulls/296/comments
+  review_comment_url: https://api.github.com/repos/davidx/prtester/pulls/comments{/number}
+  comments_url: https://api.github.com/repos/davidx/prtester/issues/296/comments
+  statuses_url: https://api.github.com/repos/davidx/prtester/statuses/5ab810d9cde984eddd5f66051192aa8fc3bec1cf
+  head:
+    label: davidx:1477931168
+    ref: '1477931168'
+    sha: 5ab810d9cde984eddd5f66051192aa8fc3bec1cf
+    user:
+      login: davidx
+      id: 17162
+      avatar_url: https://avatars.githubusercontent.com/u/17162?v=3
+      gravatar_id: ''
+      url: https://api.github.com/users/davidx
+      html_url: https://github.com/davidx
+      followers_url: https://api.github.com/users/davidx/followers
+      following_url: https://api.github.com/users/davidx/following{/other_user}
+      gists_url: https://api.github.com/users/davidx/gists{/gist_id}
+      starred_url: https://api.github.com/users/davidx/starred{/owner}{/repo}
+      subscriptions_url: https://api.github.com/users/davidx/subscriptions
+      organizations_url: https://api.github.com/users/davidx/orgs
+      repos_url: https://api.github.com/users/davidx/repos
+      events_url: https://api.github.com/users/davidx/events{/privacy}
+      received_events_url: https://api.github.com/users/davidx/received_events
+      type: User
+      site_admin: false
+    repo:
+      id: 64998050
+      name: prtester
+      full_name: davidx/prtester
+      owner:
+        login: davidx
+        id: 17162
+        avatar_url: https://avatars.githubusercontent.com/u/17162?v=3
+        gravatar_id: ''
+        url: https://api.github.com/users/davidx
+        html_url: https://github.com/davidx
+        followers_url: https://api.github.com/users/davidx/followers
+        following_url: https://api.github.com/users/davidx/following{/other_user}
+        gists_url: https://api.github.com/users/davidx/gists{/gist_id}
+        starred_url: https://api.github.com/users/davidx/starred{/owner}{/repo}
+        subscriptions_url: https://api.github.com/users/davidx/subscriptions
+        organizations_url: https://api.github.com/users/davidx/orgs
+        repos_url: https://api.github.com/users/davidx/repos
+        events_url: https://api.github.com/users/davidx/events{/privacy}
+        received_events_url: https://api.github.com/users/davidx/received_events
+        type: User
+        site_admin: false
+      private: false
+      html_url: https://github.com/davidx/prtester
+      description: testing pr
+      fork: false
+      url: https://api.github.com/repos/davidx/prtester
+      forks_url: https://api.github.com/repos/davidx/prtester/forks
+      keys_url: https://api.github.com/repos/davidx/prtester/keys{/key_id}
+      collaborators_url: https://api.github.com/repos/davidx/prtester/collaborators{/collaborator}
+      teams_url: https://api.github.com/repos/davidx/prtester/teams
+      hooks_url: https://api.github.com/repos/davidx/prtester/hooks
+      issue_events_url: https://api.github.com/repos/davidx/prtester/issues/events{/number}
+      events_url: https://api.github.com/repos/davidx/prtester/events
+      assignees_url: https://api.github.com/repos/davidx/prtester/assignees{/user}
+      branches_url: https://api.github.com/repos/davidx/prtester/branches{/branch}
+      tags_url: https://api.github.com/repos/davidx/prtester/tags
+      blobs_url: https://api.github.com/repos/davidx/prtester/git/blobs{/sha}
+      git_tags_url: https://api.github.com/repos/davidx/prtester/git/tags{/sha}
+      git_refs_url: https://api.github.com/repos/davidx/prtester/git/refs{/sha}
+      trees_url: https://api.github.com/repos/davidx/prtester/git/trees{/sha}
+      statuses_url: https://api.github.com/repos/davidx/prtester/statuses/{sha}
+      languages_url: https://api.github.com/repos/davidx/prtester/languages
+      stargazers_url: https://api.github.com/repos/davidx/prtester/stargazers
+      contributors_url: https://api.github.com/repos/davidx/prtester/contributors
+      subscribers_url: https://api.github.com/repos/davidx/prtester/subscribers
+      subscription_url: https://api.github.com/repos/davidx/prtester/subscription
+      commits_url: https://api.github.com/repos/davidx/prtester/commits{/sha}
+      git_commits_url: https://api.github.com/repos/davidx/prtester/git/commits{/sha}
+      comments_url: https://api.github.com/repos/davidx/prtester/comments{/number}
+      issue_comment_url: https://api.github.com/repos/davidx/prtester/issues/comments{/number}
+      contents_url: https://api.github.com/repos/davidx/prtester/contents/{+path}
+      compare_url: https://api.github.com/repos/davidx/prtester/compare/{base}...{head}
+      merges_url: https://api.github.com/repos/davidx/prtester/merges
+      archive_url: https://api.github.com/repos/davidx/prtester/{archive_format}{/ref}
+      downloads_url: https://api.github.com/repos/davidx/prtester/downloads
+      issues_url: https://api.github.com/repos/davidx/prtester/issues{/number}
+      pulls_url: https://api.github.com/repos/davidx/prtester/pulls{/number}
+      milestones_url: https://api.github.com/repos/davidx/prtester/milestones{/number}
+      notifications_url: https://api.github.com/repos/davidx/prtester/notifications{?since,all,participating}
+      labels_url: https://api.github.com/repos/davidx/prtester/labels{/name}
+      releases_url: https://api.github.com/repos/davidx/prtester/releases{/id}
+      deployments_url: https://api.github.com/repos/davidx/prtester/deployments
+      created_at: '2016-08-05T07:21:52Z'
+      updated_at: '2016-08-05T07:29:52Z'
+      pushed_at: '2016-10-31T21:04:57Z'
+      git_url: git://github.com/davidx/prtester.git
+      ssh_url: git@github.com:davidx/prtester.git
+      clone_url: https://github.com/davidx/prtester.git
+      svn_url: https://github.com/davidx/prtester
+      homepage:
+      size: 287
+      stargazers_count: 0
+      watchers_count: 0
+      language: Makefile
+      has_issues: true
+      has_downloads: true
+      has_wiki: true
+      has_pages: false
+      forks_count: 2
+      mirror_url:
+      open_issues_count: 3
+      forks: 2
+      open_issues: 3
+      watchers: 0
+      default_branch: master
+  base:
+    label: davidx:master
+    ref: master
+    sha: ad286051e1fc0fd8f3297008ab29faa934203c67
+    user:
+      login: davidx
+      id: 17162
+      avatar_url: https://avatars.githubusercontent.com/u/17162?v=3
+      gravatar_id: ''
+      url: https://api.github.com/users/davidx
+      html_url: https://github.com/davidx
+      followers_url: https://api.github.com/users/davidx/followers
+      following_url: https://api.github.com/users/davidx/following{/other_user}
+      gists_url: https://api.github.com/users/davidx/gists{/gist_id}
+      starred_url: https://api.github.com/users/davidx/starred{/owner}{/repo}
+      subscriptions_url: https://api.github.com/users/davidx/subscriptions
+      organizations_url: https://api.github.com/users/davidx/orgs
+      repos_url: https://api.github.com/users/davidx/repos
+      events_url: https://api.github.com/users/davidx/events{/privacy}
+      received_events_url: https://api.github.com/users/davidx/received_events
+      type: User
+      site_admin: false
+    repo:
+      id: 64998050
+      name: prtester
+      full_name: davidx/prtester
+      owner:
+        login: davidx
+        id: 17162
+        avatar_url: https://avatars.githubusercontent.com/u/17162?v=3
+        gravatar_id: ''
+        url: https://api.github.com/users/davidx
+        html_url: https://github.com/davidx
+        followers_url: https://api.github.com/users/davidx/followers
+        following_url: https://api.github.com/users/davidx/following{/other_user}
+        gists_url: https://api.github.com/users/davidx/gists{/gist_id}
+        starred_url: https://api.github.com/users/davidx/starred{/owner}{/repo}
+        subscriptions_url: https://api.github.com/users/davidx/subscriptions
+        organizations_url: https://api.github.com/users/davidx/orgs
+        repos_url: https://api.github.com/users/davidx/repos
+        events_url: https://api.github.com/users/davidx/events{/privacy}
+        received_events_url: https://api.github.com/users/davidx/received_events
+        type: User
+        site_admin: false
+      private: false
+      html_url: https://github.com/davidx/prtester
+      description: testing pr
+      fork: false
+      url: https://api.github.com/repos/davidx/prtester
+      forks_url: https://api.github.com/repos/davidx/prtester/forks
+      keys_url: https://api.github.com/repos/davidx/prtester/keys{/key_id}
+      collaborators_url: https://api.github.com/repos/davidx/prtester/collaborators{/collaborator}
+      teams_url: https://api.github.com/repos/davidx/prtester/teams
+      hooks_url: https://api.github.com/repos/davidx/prtester/hooks
+      issue_events_url: https://api.github.com/repos/davidx/prtester/issues/events{/number}
+      events_url: https://api.github.com/repos/davidx/prtester/events
+      assignees_url: https://api.github.com/repos/davidx/prtester/assignees{/user}
+      branches_url: https://api.github.com/repos/davidx/prtester/branches{/branch}
+      tags_url: https://api.github.com/repos/davidx/prtester/tags
+      blobs_url: https://api.github.com/repos/davidx/prtester/git/blobs{/sha}
+      git_tags_url: https://api.github.com/repos/davidx/prtester/git/tags{/sha}
+      git_refs_url: https://api.github.com/repos/davidx/prtester/git/refs{/sha}
+      trees_url: https://api.github.com/repos/davidx/prtester/git/trees{/sha}
+      statuses_url: https://api.github.com/repos/davidx/prtester/statuses/{sha}
+      languages_url: https://api.github.com/repos/davidx/prtester/languages
+      stargazers_url: https://api.github.com/repos/davidx/prtester/stargazers
+      contributors_url: https://api.github.com/repos/davidx/prtester/contributors
+      subscribers_url: https://api.github.com/repos/davidx/prtester/subscribers
+      subscription_url: https://api.github.com/repos/davidx/prtester/subscription
+      commits_url: https://api.github.com/repos/davidx/prtester/commits{/sha}
+      git_commits_url: https://api.github.com/repos/davidx/prtester/git/commits{/sha}
+      comments_url: https://api.github.com/repos/davidx/prtester/comments{/number}
+      issue_comment_url: https://api.github.com/repos/davidx/prtester/issues/comments{/number}
+      contents_url: https://api.github.com/repos/davidx/prtester/contents/{+path}
+      compare_url: https://api.github.com/repos/davidx/prtester/compare/{base}...{head}
+      merges_url: https://api.github.com/repos/davidx/prtester/merges
+      archive_url: https://api.github.com/repos/davidx/prtester/{archive_format}{/ref}
+      downloads_url: https://api.github.com/repos/davidx/prtester/downloads
+      issues_url: https://api.github.com/repos/davidx/prtester/issues{/number}
+      pulls_url: https://api.github.com/repos/davidx/prtester/pulls{/number}
+      milestones_url: https://api.github.com/repos/davidx/prtester/milestones{/number}
+      notifications_url: https://api.github.com/repos/davidx/prtester/notifications{?since,all,participating}
+      labels_url: https://api.github.com/repos/davidx/prtester/labels{/name}
+      releases_url: https://api.github.com/repos/davidx/prtester/releases{/id}
+      deployments_url: https://api.github.com/repos/davidx/prtester/deployments
+      created_at: '2016-08-05T07:21:52Z'
+      updated_at: '2016-08-05T07:29:52Z'
+      pushed_at: '2016-10-31T21:04:57Z'
+      git_url: git://github.com/davidx/prtester.git
+      ssh_url: git@github.com:davidx/prtester.git
+      clone_url: https://github.com/davidx/prtester.git
+      svn_url: https://github.com/davidx/prtester
+      homepage:
+      size: 287
+      stargazers_count: 0
+      watchers_count: 0
+      language: Makefile
+      has_issues: true
+      has_downloads: true
+      has_wiki: true
+      has_pages: false
+      forks_count: 2
+      mirror_url:
+      open_issues_count: 3
+      forks: 2
+      open_issues: 3
+      watchers: 0
+      default_branch: master
+  _links:
+    self:
+      href: https://api.github.com/repos/davidx/prtester/pulls/296
+    html:
+      href: https://github.com/davidx/prtester/pull/296
+    issue:
+      href: https://api.github.com/repos/davidx/prtester/issues/296
+    comments:
+      href: https://api.github.com/repos/davidx/prtester/issues/296/comments
+    review_comments:
+      href: https://api.github.com/repos/davidx/prtester/pulls/296/comments
+    review_comment:
+      href: https://api.github.com/repos/davidx/prtester/pulls/comments{/number}
+    commits:
+      href: https://api.github.com/repos/davidx/prtester/pulls/296/commits
+    statuses:
+      href: https://api.github.com/repos/davidx/prtester/statuses/5ab810d9cde984eddd5f66051192aa8fc3bec1cf
+repository:
+  id: 64998050
+  name: prtester
+  full_name: davidx/prtester
+  owner:
+    login: davidx
+    id: 17162
+    avatar_url: https://avatars.githubusercontent.com/u/17162?v=3
+    gravatar_id: ''
+    url: https://api.github.com/users/davidx
+    html_url: https://github.com/davidx
+    followers_url: https://api.github.com/users/davidx/followers
+    following_url: https://api.github.com/users/davidx/following{/other_user}
+    gists_url: https://api.github.com/users/davidx/gists{/gist_id}
+    starred_url: https://api.github.com/users/davidx/starred{/owner}{/repo}
+    subscriptions_url: https://api.github.com/users/davidx/subscriptions
+    organizations_url: https://api.github.com/users/davidx/orgs
+    repos_url: https://api.github.com/users/davidx/repos
+    events_url: https://api.github.com/users/davidx/events{/privacy}
+    received_events_url: https://api.github.com/users/davidx/received_events
+    type: User
+    site_admin: false
+  private: false
+  html_url: https://github.com/davidx/prtester
+  description: testing pr
+  fork: false
+  url: https://api.github.com/repos/davidx/prtester
+  forks_url: https://api.github.com/repos/davidx/prtester/forks
+  keys_url: https://api.github.com/repos/davidx/prtester/keys{/key_id}
+  collaborators_url: https://api.github.com/repos/davidx/prtester/collaborators{/collaborator}
+  teams_url: https://api.github.com/repos/davidx/prtester/teams
+  hooks_url: https://api.github.com/repos/davidx/prtester/hooks
+  issue_events_url: https://api.github.com/repos/davidx/prtester/issues/events{/number}
+  events_url: https://api.github.com/repos/davidx/prtester/events
+  assignees_url: https://api.github.com/repos/davidx/prtester/assignees{/user}
+  branches_url: https://api.github.com/repos/davidx/prtester/branches{/branch}
+  tags_url: https://api.github.com/repos/davidx/prtester/tags
+  blobs_url: https://api.github.com/repos/davidx/prtester/git/blobs{/sha}
+  git_tags_url: https://api.github.com/repos/davidx/prtester/git/tags{/sha}
+  git_refs_url: https://api.github.com/repos/davidx/prtester/git/refs{/sha}
+  trees_url: https://api.github.com/repos/davidx/prtester/git/trees{/sha}
+  statuses_url: https://api.github.com/repos/davidx/prtester/statuses/{sha}
+  languages_url: https://api.github.com/repos/davidx/prtester/languages
+  stargazers_url: https://api.github.com/repos/davidx/prtester/stargazers
+  contributors_url: https://api.github.com/repos/davidx/prtester/contributors
+  subscribers_url: https://api.github.com/repos/davidx/prtester/subscribers
+  subscription_url: https://api.github.com/repos/davidx/prtester/subscription
+  commits_url: https://api.github.com/repos/davidx/prtester/commits{/sha}
+  git_commits_url: https://api.github.com/repos/davidx/prtester/git/commits{/sha}
+  comments_url: https://api.github.com/repos/davidx/prtester/comments{/number}
+  issue_comment_url: https://api.github.com/repos/davidx/prtester/issues/comments{/number}
+  contents_url: https://api.github.com/repos/davidx/prtester/contents/{+path}
+  compare_url: https://api.github.com/repos/davidx/prtester/compare/{base}...{head}
+  merges_url: https://api.github.com/repos/davidx/prtester/merges
+  archive_url: https://api.github.com/repos/davidx/prtester/{archive_format}{/ref}
+  downloads_url: https://api.github.com/repos/davidx/prtester/downloads
+  issues_url: https://api.github.com/repos/davidx/prtester/issues{/number}
+  pulls_url: https://api.github.com/repos/davidx/prtester/pulls{/number}
+  milestones_url: https://api.github.com/repos/davidx/prtester/milestones{/number}
+  notifications_url: https://api.github.com/repos/davidx/prtester/notifications{?since,all,participating}
+  labels_url: https://api.github.com/repos/davidx/prtester/labels{/name}
+  releases_url: https://api.github.com/repos/davidx/prtester/releases{/id}
+  deployments_url: https://api.github.com/repos/davidx/prtester/deployments
+  created_at: '2016-08-05T07:21:52Z'
+  updated_at: '2016-08-05T07:29:52Z'
+  pushed_at: '2016-10-31T21:04:57Z'
+  git_url: git://github.com/davidx/prtester.git
+  ssh_url: git@github.com:davidx/prtester.git
+  clone_url: https://github.com/davidx/prtester.git
+  svn_url: https://github.com/davidx/prtester
+  homepage:
+  size: 287
+  stargazers_count: 0
+  watchers_count: 0
+  language: Makefile
+  has_issues: true
+  has_downloads: true
+  has_wiki: true
+  has_pages: false
+  forks_count: 2
+  mirror_url:
+  open_issues_count: 3
+  forks: 2
+  open_issues: 3
+  watchers: 0
+  default_branch: master
+sender:
+  login: davidpuddy1
+  id: 20779719
+  avatar_url: https://avatars.githubusercontent.com/u/20779719?v=3
+  gravatar_id: ''
+  url: https://api.github.com/users/davidpuddy1
+  html_url: https://github.com/davidpuddy1
+  followers_url: https://api.github.com/users/davidpuddy1/followers
+  following_url: https://api.github.com/users/davidpuddy1/following{/other_user}
+  gists_url: https://api.github.com/users/davidpuddy1/gists{/gist_id}
+  starred_url: https://api.github.com/users/davidpuddy1/starred{/owner}{/repo}
+  subscriptions_url: https://api.github.com/users/davidpuddy1/subscriptions
+  organizations_url: https://api.github.com/users/davidpuddy1/orgs
+  repos_url: https://api.github.com/users/davidpuddy1/repos
+  events_url: https://api.github.com/users/davidpuddy1/events{/privacy}
+  received_events_url: https://api.github.com/users/davidpuddy1/received_events
+  type: User
+  site_admin: false

--- a/test/test.rb
+++ b/test/test.rb
@@ -10,4 +10,4 @@ require 'test/test_persisted_build_status'
 require 'test/test_build_steps'
 require 'test/test_state'
 require 'test/test_common'
-
+require 'test/test_code_approvals'

--- a/test/test_code_approvals.rb
+++ b/test/test_code_approvals.rb
@@ -1,0 +1,78 @@
+unit_tests do
+
+  test "should  respond to get_pull_request_by_id" do
+    default_vcr_state do
+      prw = Thumbs::PullRequestWorker.new(:repo => TESTREPO, :pr => TESTPR)
+      assert prw.respond_to?(:get_pull_request_by_id)
+
+    end
+  end
+  test "should  respond to get_reviews_by_pr_id" do
+    default_vcr_state do
+      prw = Thumbs::PullRequestWorker.new(:repo => TESTREPO, :pr => TESTPR)
+      assert prw.respond_to?(:get_reviews_by_pr_id)
+    end
+  end
+
+  test "should  respond to run_graph_query" do
+    default_vcr_state do
+      prw = Thumbs::PullRequestWorker.new(:repo => TESTREPO, :pr => TESTPR)
+      assert prw.respond_to?(:run_graph_query)
+    end
+  end
+
+  test "should  respond to approvals" do
+    default_vcr_state do
+      prw = Thumbs::PullRequestWorker.new(:repo => TESTREPO, :pr => TESTPR)
+      assert prw.respond_to?(:approvals)
+      assert prw.approvals.length == 0
+      assert_equal prw.get_approvals(prw.get_pull_request_id), prw.approvals
+
+    end
+  end
+
+  test "should  respond to get_approvals" do
+    default_vcr_state do
+      prw = Thumbs::PullRequestWorker.new(:repo => TESTREPO, :pr => TESTPR)
+      assert prw.respond_to?(:get_approvals)
+      assert prw.approvals.length == 0
+      code_reviews = prw.get_reviews_by_pr_id(prw.get_pull_request_id)
+      approvals_by_pr_id=code_reviews.collect{|r| r if r['state'] == 'APPROVED'}.compact
+      assert_equal approvals_by_pr_id, prw.get_approvals(prw.get_pull_request_id)
+    end
+  end
+
+  test "should  respond to approval_count" do
+    default_vcr_state do
+      prw = Thumbs::PullRequestWorker.new(:repo => TESTREPO, :pr => TESTPR)
+      assert prw.respond_to?(:approval_count)
+      assert prw.approval_count == 0
+      assert_equal prw.approvals.length, prw.approval_count
+    end
+  end
+
+  test "should respond to comment_code_approvals" do
+    default_vcr_state do
+      prw = Thumbs::PullRequestWorker.new(:repo => TESTREPO, :pr => TESTPR)
+      assert prw.respond_to?(:reviews)
+      assert_equal prw.approvals + prw.comment_code_approvals, prw.reviews
+    end
+  end
+
+  test "reviews should be a combination of comment_code_approvals and github code approvals" do
+    default_vcr_state do
+      prw = Thumbs::PullRequestWorker.new(:repo => TESTREPO, :pr => TESTPR)
+      assert prw.respond_to?(:reviews)
+      assert_equal prw.approvals + prw.comment_code_approvals, prw.reviews
+    end
+
+  end
+  test "reviews_count should be a combination of comment_code_approvals and github code approvals" do
+    default_vcr_state do
+      prw = Thumbs::PullRequestWorker.new(:repo => TESTREPO, :pr => TESTPR)
+      assert_equal prw.approval_count + prw.comment_code_approval_count, prw.review_count
+    end
+
+  end
+
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -40,7 +40,7 @@ def default_vcr_state(&block)
         cassette(:get_events_other, :allow_playback_repeats => true) do
           cassette(:get_events, :allow_playback_repeats => true, :record => :new_episodes) do
             cassette(:get_pull_events, :record => :all, :allow_playback_repeats => true) do
-            block.call
+              block.call
             end
           end
         end

--- a/test/test_payload.rb
+++ b/test/test_payload.rb
@@ -82,4 +82,10 @@ unit_tests do
 
     assert payload_type(merged_base_payload) == :merged_base, payload_type(merged_base_payload).to_s
   end
+
+  test "can detect new approal  payload type" do
+    new_approval_base_payload = { 'approval' => 'yes'}
+
+    assert payload_type(merged_base_payload) == :merged_base, payload_type(merged_base_payload).to_s
+  end
 end

--- a/test/test_payload.rb
+++ b/test/test_payload.rb
@@ -83,9 +83,43 @@ unit_tests do
     assert payload_type(merged_base_payload) == :merged_base, payload_type(merged_base_payload).to_s
   end
 
-  test "can detect new approal  payload type" do
-    new_approval_base_payload = { 'approval' => 'yes'}
+  test "can detect code approval payload type" do
+    default_payload_contents = {
+      'repository' => {'full_name' => "org/user"},
+      'issue' => {'number' => 1,
+                  'pull_request' => {'number' => 1}
+      },
+    }
+    code_approval_payload = {'action' => 'submitted', 'review' => { 'state' => 'approved'}}
 
-    assert payload_type(merged_base_payload) == :merged_base, payload_type(merged_base_payload).to_s
+    payload = default_payload_contents.merge( code_approval_payload )
+
+    assert payload_type(payload) == :code_approval, payload_type(payload).to_s
+  end
+  test "can detect code comment payload type" do
+    default_payload_contents = {
+        'repository' => {'full_name' => "org/user"},
+        'issue' => {'number' => 1,
+                    'pull_request' => {'number' => 1}
+        },
+    }
+    code_comment_payload = {'action' => 'submitted', 'review' => { 'state' => 'commented'}}
+
+    payload = default_payload_contents.merge( code_comment_payload )
+
+    assert payload_type(payload) == :code_comment, payload_type(payload).to_s
+  end
+  test "can detect code change requested payload type" do
+    default_payload_contents = {
+        'repository' => {'full_name' => "org/user"},
+        'issue' => {'number' => 1,
+                    'pull_request' => {'number' => 1}
+        },
+    }
+    code_change_payload = {'action' => 'submitted', 'review' => { 'state' => 'changes_requested'}}
+
+    payload = default_payload_contents.merge( code_change_payload )
+
+    assert payload_type(payload) == :code_change_requested, payload_type(payload).to_s
   end
 end


### PR DESCRIPTION
This enable support for github code approvals.
When thumbs counts code reviews to compare to minimum_reviewers, it will now count the code approvals. 
You may use comment based +1 as well as github code approvals interchangeably.(it adds up both)

Main flaw to be fixed shortly is: if a user leaves a code review comment as well as a code approval, it'll count that twice. 
A user may post many +1s it'l only count one, same for approvals, it'll only count a single one. Not yet unique counting across both. 
Resets count when you push, same old behavior.

This was implemented using the new github graphql api as code approvals are only available via the events webhook service, not yet on the normal rest api.
Likely to be refactored once github releases more support for the feature in their api.

