### PR TITLE
fix for ref with slashes in it

### DIFF
--- a/.thumbs.yml
+++ b/.thumbs.yml
@@ -4,4 +4,4 @@ build_steps:
  - BUNDLE_GEMFILE=Gemfile bundle install
  - BUNDLE_GEMFILE=Gemfile bundle exec ruby test/test.rb
 org_mode: true
-timeout: 1803
+timeout: 1804

--- a/lib/thumbs/pull_request_worker.rb
+++ b/lib/thumbs/pull_request_worker.rb
@@ -300,7 +300,7 @@ module Thumbs
     end
 
     def build_guid
-      "#{pr.base.ref}:#{most_recent_base_sha.slice(0,7)}:#{pr.head.ref}:#{most_recent_head_sha.slice(0,7)}"
+      "#{pr.base.ref.gsub(/\//,'_')}:#{most_recent_base_sha.slice(0,7)}:#{pr.head.ref.gsub(/\//,'_')}:#{most_recent_head_sha.slice(0,7)}"
     end
     def set_build_progress(progress_status)
       update_or_create_build_status(most_recent_head_sha, progress_status)

--- a/test/test_common.rb
+++ b/test/test_common.rb
@@ -5,7 +5,7 @@ unit_tests do
   test "should be able to generate base and sha specific build guid" do
     default_vcr_state do
       assert PRW.respond_to?(:build_guid)
-      assert_equal "#{PRW.pr.base.ref}:#{PRW.pr.base.sha.slice(0,7)}:#{PRW.pr.head.ref}:#{PRW.pr.head.sha.slice(0,7)}", PRW.build_guid
+      assert_equal "#{PRW.pr.base.ref.gsub(/\//, '_')}:#{PRW.pr.base.sha.slice(0,7)}:#{PRW.pr.head.ref.gsub(/\//, '_')}:#{PRW.pr.head.sha.slice(0,7)}", PRW.build_guid
     end
   end
 
@@ -64,6 +64,7 @@ unit_tests do
 
       end
   end
+
 end
 
 


### PR DESCRIPTION
This is a fix for a situation where a ref, base or head, happens to include slashes.
This prohibited persistence of build status as the build guid used in the filename includes the ref.
as a simple initial solution, the build guid has been modified to replace '/' with '_' 
Example of bug:  https://github.com/basho/yokozuna/pull/699 
Example of pr with slashes working under this code: https://github.com/davidx/prtester/pull/310