### PR TITLE
Change build guid to be more makefile friendly

### DIFF
--- a/lib/thumbs/pull_request_worker.rb
+++ b/lib/thumbs/pull_request_worker.rb
@@ -300,7 +300,7 @@ module Thumbs
     end
 
     def build_guid
-      "#{pr.base.ref.gsub(/\//,'_')}:#{most_recent_base_sha.slice(0,7)}:#{pr.head.ref.gsub(/\//,'_')}:#{most_recent_head_sha.slice(0,7)}"
+      "#{pr.base.ref.gsub(/\//,'_')}##{most_recent_base_sha.slice(0,7)}##{pr.head.ref.gsub(/\//,'_')}##{most_recent_head_sha.slice(0,7)}"
     end
     def set_build_progress(progress_status)
       update_or_create_build_status(most_recent_head_sha, progress_status)

--- a/test/test_common.rb
+++ b/test/test_common.rb
@@ -5,7 +5,7 @@ unit_tests do
   test "should be able to generate base and sha specific build guid" do
     default_vcr_state do
       assert PRW.respond_to?(:build_guid)
-      assert_equal "#{PRW.pr.base.ref.gsub(/\//, '_')}:#{PRW.pr.base.sha.slice(0,7)}:#{PRW.pr.head.ref.gsub(/\//, '_')}:#{PRW.pr.head.sha.slice(0,7)}", PRW.build_guid
+      assert_equal "#{PRW.pr.base.ref.gsub(/\//, '_')}##{PRW.pr.base.sha.slice(0,7)}##{PRW.pr.head.ref.gsub(/\//, '_')}##{PRW.pr.head.sha.slice(0,7)}", PRW.build_guid
     end
   end
 


### PR DESCRIPTION
This fixes a build failure on https://github.com/basho/yokozuna/pull/700
caused by ":" characters existing in the build path.
These have been replaced by "#" characters. 