### PR TITLE
Add text to the header line for PR status comments

### DIFF
--- a/lib/thumbs/pull_request_worker.rb
+++ b/lib/thumbs/pull_request_worker.rb
@@ -353,8 +353,8 @@ module Thumbs
     def compose_build_status_comment_title(progress_status)
       pr = client.pull_request(repo, @pr.number)
       status_emoji=(progress_status==:completed ? result_image(aggregate_build_status_result) : result_image(progress_status))
-      comment_title="|||||\n"
-      comment_title<<"------------ | -------------|------------ | ------------- | -------------\n"
+      comment_title="Compare | | Base | Status\n"
+      comment_title<<"------------ | ------------- | ------------- | -------------\n"
       comment_title<<"#{pr.head.ref} #{most_recent_head_sha.slice(0, 7)} | :arrow_right: | #{pr.base.ref} #{most_recent_base_sha.slice(0, 7)} | #{status_emoji} #{progress_status}"
       comment_title
     end


### PR DESCRIPTION
Without at least a single non-whitespace character in a field, the table
doesn't render in Github.

Fixes #35 