### PR TITLE
fix guid

### DIFF
--- a/lib/thumbs/pull_request_worker.rb
+++ b/lib/thumbs/pull_request_worker.rb
@@ -346,7 +346,7 @@ module Thumbs
     end
 
     def build_guid
-      "#{pr.base.ref.gsub(/\//, '_')}##{most_recent_base_sha.slice(0, 7)}##{pr.head.ref.gsub(/\//, '_')}##{most_recent_head_sha.slice(0, 7)}"
+      "#{pr.base.ref.gsub(/\//, '_')}.#{most_recent_base_sha.slice(0, 7)}.#{pr.head.ref.gsub(/\//, '_')}.#{most_recent_head_sha.slice(0, 7)}"
     end
 
     def set_build_progress(progress_status)

--- a/test/test_common.rb
+++ b/test/test_common.rb
@@ -3,7 +3,7 @@ unit_tests do
   test "should be able to generate base and sha specific build guid" do
     default_vcr_state do
       assert PRW.respond_to?(:build_guid)
-      assert_equal "#{PRW.pr.base.ref.gsub(/\//, '_')}##{PRW.pr.base.sha.slice(0, 7)}##{PRW.pr.head.ref.gsub(/\//, '_')}##{PRW.pr.head.sha.slice(0, 7)}", PRW.build_guid
+      assert_equal "#{PRW.pr.base.ref.gsub(/\//, '_')}.#{PRW.pr.base.sha.slice(0, 7)}.#{PRW.pr.head.ref.gsub(/\//, '_')}.#{PRW.pr.head.sha.slice(0, 7)}", PRW.build_guid
     end
   end
 


### PR DESCRIPTION
This fixes potential issues with build scripts that have problems with '#' in directory names.
Using "." dots now.
http://stackoverflow.com/questions/2304221/what-character-sequence-should-i-not-allow-in-a-filename

http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_282