### PR TITLE
Use pagination argument to increase page size.

### DIFF
--- a/.thumbs.yml
+++ b/.thumbs.yml
@@ -4,7 +4,7 @@ build_steps:
  - BUNDLE_GEMFILE=Gemfile bundle install
  - BUNDLE_GEMFILE=Gemfile bundle exec ruby test/test.rb
 # optional
-merge: false
+merge: true
 org_mode: true
 timeout: 1805
 shell: /bin/bash

--- a/lib/thumbs/pull_request_worker.rb
+++ b/lib/thumbs/pull_request_worker.rb
@@ -204,7 +204,7 @@ module Thumbs
     end
 
     def all_comments
-      client.issue_comments(repo, pr.number)
+      client.issue_comments(repo, pr.number, per_page: 100)
     end
 
     def comments

--- a/test/test_build_steps.rb
+++ b/test/test_build_steps.rb
@@ -288,7 +288,7 @@ unit_tests do
     default_vcr_state do
       comments = PRW.comments
       sha_time_stamp=PRW.push_time_stamp(PRW.pr.head.sha)
-      comments_after_sha=PRW.client.issue_comments(PRW.repo, PRW.pr.number).collect { |c| c.to_h if c[:created_at] > sha_time_stamp }.compact
+      comments_after_sha=PRW.client.issue_comments(PRW.repo, PRW.pr.number, per_page: 100).collect { |c| c.to_h if c[:created_at] > sha_time_stamp }.compact
       assert_equal comments_after_sha, comments
     end
   end

--- a/test/test_common.rb
+++ b/test/test_common.rb
@@ -92,6 +92,13 @@ unit_tests do
       assert_equal '/bin/bash', status[:output].strip, status[:output]
     end
   end
+  test "can get more than 30 comments" do
+    default_vcr_state do
+      PRW.respond_to?(:all_comments)
+      prw=Thumbs::PullRequestWorker.new(repo: 'davidx/prtester', pr: 318)
+      assert prw.all_comments.length > 30
+    end
+  end
 end
 
 

--- a/test/test_state.rb
+++ b/test/test_state.rb
@@ -2,8 +2,8 @@ unit_tests do
   test "can read build progress status" do
     default_vcr_state do
       cassette(:clear_build_comment, :allow_playback_repeats => true, :record => :all) do
-        PRW.clear_build_progress_comment
-        assert_equal :unstarted, PRW.build_progress_status
+        prw=Thumbs::PullRequestWorker.new(repo: 'thumbot/prtester', pr: 446)
+        assert_equal :unstarted, prw.build_progress_status
       end
     end
   end


### PR DESCRIPTION
This is a fix for a scenario where the amount of comments on a PR reaches over 30. By default the github API responds with result set of 30 or less.
This adds a argument per_page: 100 to increase this.

Phase 2 of this improvement will be to iterate over available pages flushing them until empty.

