### PR TITLE
PR rebuild Trigger horizon

### DIFF
--- a/.thumbs.yml
+++ b/.thumbs.yml
@@ -1,8 +1,8 @@
 # required
 minimum_reviewers: 2
 build_steps:
- - BUNDLE_GEMFILE=Gemfile bundle install
- - BUNDLE_GEMFILE=Gemfile bundle exec ruby test/test.rb
+ - Gemfile bundle install
+ - Gemfile bundle exec ruby test/test.rb
 # optional
 merge: true
 org_mode: true

--- a/.thumbs.yml
+++ b/.thumbs.yml
@@ -1,8 +1,8 @@
 # required
 minimum_reviewers: 2
 build_steps:
- - Gemfile bundle install
- - Gemfile bundle exec ruby test/test.rb
+ - bundle install
+ - bundle exec ruby test/test.rb
 # optional
 merge: true
 org_mode: true

--- a/app.rb
+++ b/app.rb
@@ -99,6 +99,7 @@ Thanks @#{pr_worker.pr.user.login}!
           pr_worker.create_build_status_comment
           return "OK"
         end
+        return "OK" if pr_worker.build_in_progress?
         pr_worker.validate
 
         if pr_worker.valid_for_merge?

--- a/lib/thumbs/pull_request_worker.rb
+++ b/lib/thumbs/pull_request_worker.rb
@@ -813,7 +813,7 @@ module Thumbs
     end
 
     def approvals
-      if @thumb_config.key?('org_mode') && @thumb_config['org_mode']
+      if thumb_config.key?('org_mode') && thumb_config['org_mode']
         debug_message "returning org_member_code_approvals"
         return org_member_approvals
       end

--- a/lib/thumbs/pull_request_worker.rb
+++ b/lib/thumbs/pull_request_worker.rb
@@ -480,8 +480,8 @@ module Thumbs
     def validate
       build_status = read_build_status
 
-      refresh_repo
       unless build_status.key?(:steps) && build_status[:steps].keys.length > 0
+        refresh_repo
         debug_message "no build status found, running build steps"
         try_merge
         run_build_steps

--- a/lib/thumbs/pull_request_worker.rb
+++ b/lib/thumbs/pull_request_worker.rb
@@ -32,8 +32,7 @@ module Thumbs
     end
 
     def prepare_build_dir
-      cleanup_build_dir
-      clone
+      refresh_repo
       try_merge
     end
 

--- a/test/test_common.rb
+++ b/test/test_common.rb
@@ -95,7 +95,7 @@ unit_tests do
   test "can get more than 30 comments" do
     default_vcr_state do
       PRW.respond_to?(:all_comments)
-      prw=Thumbs::PullRequestWorker.new(repo: 'davidx/prtester', pr: 318)
+      prw=Thumbs::PullRequestWorker.new(repo: 'davidx/prtester', pr: 321)
       assert prw.all_comments.length > 30
     end
   end


### PR DESCRIPTION
This adds behavior to the PR rebuilds that occur after a new base gets merged.
After a pr is selected for rebuild, it will now check to see if it isn't too old, and will skip it if older than 90 days.