### PR TITLE
github comment_character_limit

### DIFF
--- a/lib/thumbs/pull_request_worker.rb
+++ b/lib/thumbs/pull_request_worker.rb
@@ -702,7 +702,10 @@ module Thumbs
 
 <%= status[:command] %>
 
-<%= status[:output].slice!(0,10000) %>
+<% output=status[:output] %>
+<% allowed_length=10000 %>
+<%= output.slice!(output.length-allowed_length, output.length) %>
+
 
 ```
 
@@ -719,8 +722,11 @@ module Thumbs
       comment_message = compose_build_status_comment_title(:completed)
       comment_message << "\n#{@status_title}"
       comment_message << build_comment
-      comment_message.slice!(0,65000)
-      update_pull_request_comment(comment_id, comment_message)
+      if comment_message.length > 65000
+        debug_message "comment_message too large : #{comment_message.length} unable to post"
+      else
+        update_pull_request_comment(comment_id, comment_message)
+      end
     end
 
     def render_reviewers_comment_template

--- a/lib/thumbs/pull_request_worker.rb
+++ b/lib/thumbs/pull_request_worker.rb
@@ -702,7 +702,7 @@ module Thumbs
 
 <%= status[:command] %>
 
-<%= status[:output] %>
+<%= status[:output].slice!(0,10000) %>
 
 ```
 
@@ -719,6 +719,7 @@ module Thumbs
       comment_message = compose_build_status_comment_title(:completed)
       comment_message << "\n#{@status_title}"
       comment_message << build_comment
+      comment_message.slice!(0,65000)
       update_pull_request_comment(comment_id, comment_message)
     end
 

--- a/lib/thumbs/pull_request_worker.rb
+++ b/lib/thumbs/pull_request_worker.rb
@@ -704,7 +704,14 @@ module Thumbs
 
 <% output=status[:output] %>
 <% allowed_length=10000 %>
-<%= output.slice!(output.length-allowed_length, output.length) %>
+<% if output.length > allowed_length %>
+  <% snipped_characters = output.length - allowed_length %>
+  <% snipped_lines = output.slice(0, output.length-allowed_length).split(/\n/) %>
+... Snipped <%= snipped_lines.length %> lines ...
+<%= output.slice(output.length-allowed_length, output.length) %>
+<% else %>
+  <%= output %>
+<% end %>
 
 
 ```


### PR DESCRIPTION
This is an initial fix to the issue https://github.com/basho-labs/thumbs/issues/55 
https://github.com/basho/riak_kv/pull/1560
Gists still contain full output. (Given github gist size limitiations.)
