### PR TITLE
add wait_lock?

### DIFF
--- a/lib/thumbs/pull_request_worker.rb
+++ b/lib/thumbs/pull_request_worker.rb
@@ -344,6 +344,11 @@ module Thumbs
         return false
       end
 
+      if wait_lock?
+        debug_message "wait_lock? thumbot wait set. delete comment to release lock"
+        return false
+      end
+
       unless thumb_config['merge'] == true
         debug_message "thumb_config['merge'] != 'true' || thumbs config says: merge: #{thumb_config['merge'].inspect}"
         return false
@@ -580,6 +585,14 @@ module Thumbs
         debug_message ".thumbs.yml config says no merge"
         status[:result]=:error
         status[:message]=".thumbs.yml config merge=false"
+        status[:ended_at]=DateTime.now
+        return status
+      end
+
+      if wait_lock?
+        debug_message "wait_lock? thumbot wait enabled."
+        status[:result]=:error
+        status[:message]="wait_lock? thumbot wait enabled."
         status[:ended_at]=DateTime.now
         return status
       end
@@ -958,6 +971,10 @@ module Thumbs
       debug_message "pr.base.repo.full_name #{pr.base.repo.full_name}"
       debug_message "pr.head.repo.full_name #{pr.head.repo.full_name}"
       pr.base.repo.full_name != pr.head.repo.full_name ? true : false
+    end
+
+    def wait_lock?
+      all_comments.any? {|comment| comment[:body] =~  /^thumbot wait/ }
     end
 
     private


### PR DESCRIPTION
This adds a feature that allows you do lock a PR temporarily.
```
thumbot wait
```
For example, you might create a PR and someone might make comments on the code that you intend to implement before merging. 
When in merge:true,  this is telling the bot to not automerge this specific PR.
Providing a quick pause button to address some issues in the branch if needed.
It also communicates to team members not to merge the PR yet.
When in merge:false, it helps mainly around preventing others from merging the code until it is re-finalized per code review comments. When you're ready to unlock, just remove your comment and trigger it separately as usual. +1 trigger or thumbot merge