### PR TITLE
dont show config when asked

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -58,7 +58,7 @@ Thanks @#{pr_worker.pr.user.login}!
 </details>
         
         EOS
-        pr_worker.add_comment(intro_text)
+        pr_worker.add_comment(intro_text) unless pr_worker.thumb_config['show_config'] == false
         pr_worker.set_build_progress(:in_progress)
         pr_worker.try_merge
         unless pr_worker.thumb_config && pr_worker.thumb_config.key?('build_steps')


### PR DESCRIPTION
This omits displaying the initial thank you and config settings on request. 
```
show_config: false # default is true
```
example: https://github.com/davidx/prtester/pull/330