### PR TITLE
WIP - Exclude thumbs commits for comments_since_..., i.e. for comment approvals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+Gemfile.lock
 *.gem
 *.rbc
 /.config

--- a/lib/thumbs/pull_request_worker.rb
+++ b/lib/thumbs/pull_request_worker.rb
@@ -1,47 +1,66 @@
 module Thumbs
   class PullRequestWorker
     attr_reader :build_dir
-    attr_reader :build_status
-    attr_accessor :build_steps
-    attr_reader :minimum_reviewers
     attr_reader :repo
     attr_reader :pr
-    attr_accessor :thumb_config
     attr_reader :log
     attr_reader :org
-    attr_accessor :client
-    attr_reader :pull_request_id
+    attr_reader :thumbs_config_default
 
     def initialize(options)
-      @repo = options[:repo]
-      @org = repo.split('/').first
-      @client = Octokit::Client.new(:netrc => true)
-      @pr = @client.pull_request(options[:repo], options[:pr])
-      @pull_request_id=get_pull_request_id
-      @build_dir=options[:build_dir] || "/tmp/thumbs/#{build_guid}"
-      persisted_build_status = read_build_status
-      @build_status = persisted_build_status || {:steps => {}}
-      @build_steps = []
+      if options[:url]
+        @repo, @pr = parse_github_pr_url(options[:url])
+      end
+      @repo ||= options[:repo]
+      @org = @repo.split('/').first
+      @pr ||= options[:pr]
+      @build_dir = options[:build_dir] || "/tmp/thumbs/#{build_guid}"
+      @thumbs_config_default = options[:thumbs_config_default]
+
       prepare_build_dir
-      load_thumbs_config
-      @minimum_reviewers = thumb_config && thumb_config.key?('minimum_reviewers') ? thumb_config['minimum_reviewers'] : 2
-      @timeout=thumb_config && thumb_config.key?('timeout') ? thumb_config['timeout'] : 1800
+    end
+
+    def reset_state
+      @pull_request =
+      @event =
+      @open_pull_requests =
+      @commits =
+      @base_commits =
+      @head_commits =
+      @comments_since_most_recent_commit =
+      nil
+    end
+
+    def octokit_client
+      @octokit_client ||= Octokit::Client.new(:netrc => true)
+    end
+
+    def pull_request
+      @pull_request ||= octokit_client.pull_request(repo, pr)
     end
 
     def reset_build_status
-      @build_status={:steps => {}}
+      @build_status = {:steps => {}}
+    end
+
+    def build_status
+      return @build_status if @build_status
+      persisted_build_status = read_build_status
+      @build_status = persisted_build_status || {:steps => {}}
     end
 
     def prepare_build_dir
+      return if @prepared_bulid_dir
       refresh_repo
-      try_merge
+      res = try_merge
+      @prepared_bulid_dir = true
+      res
     end
-
 
     def refresh_repo
       debug_message "refreshing repo"
-      if File.exists?(@build_dir) && Git.open(@build_dir).index.readable?
-        git = Git.open(@build_dir)
+      if File.exists?(build_dir) && Git.open(build_dir).index.readable?
+        git = Git.open(build_dir)
         git.fetch
         debug_message "fetch"
         git
@@ -51,74 +70,72 @@ module Thumbs
       end
     end
 
-    def clone(dir=build_dir)
-      status={}
-      status[:started_at]=DateTime.now
+    def clone()
+      dir = build_dir
+      status = {}
+      status[:started_at] = DateTime.now
       begin
-        git = Git.clone("git@github.com:#{pr.base.repo.full_name}", dir)
+        git = Git.clone("git@github.com:#{pull_request.base.repo.full_name}", dir)
       rescue => e
-        status[:ended_at]=DateTime.now
-        status[:result]=:error
-        status[:message]="Clone failed!"
-        status[:output]=e
-        @build_status[:steps][:clone]=status
+        status[:ended_at] = DateTime.now
+        status[:result] = :error
+        status[:message] = "Clone failed!"
+        status[:output] = e
+        build_status[:steps][:clone] = status
         return status
       end
       git
     end
 
     def try_merge
-      pr_branch="feature_#{DateTime.now.strftime("%s")}"
+      pr_branch = "feature_#{DateTime.now.strftime("%s")}"
 
-      status={}
-      status[:started_at]=DateTime.now
+      status = {}
+      status[:started_at] = DateTime.now
 
-
-      debug_message "Trying merge #{pr.base.repo.full_name}:PR##{pr.number} \" #{pr.title}\" #{pr.head.repo.full_name}##{most_recent_head_sha} onto #{@pr.base.ref} #{most_recent_base_sha}"
+      debug_message "Trying merge #{pull_request.base.repo.full_name}:PR##{pull_request.number} \" #{pull_request.title}\" #{pull_request.head.repo.full_name}##{most_recent_head_sha} onto #{pull_request.base.ref} #{most_recent_base_sha}"
       begin
         git = refresh_repo
         git.reset
-        git.checkout(pr.base.ref)
+        git.checkout(pull_request.base.ref)
         git.branch(pr_branch).checkout
-        debug_message "Trying merge #{@repo}:PR##{@pr.number} \" #{@pr.title}\" #{most_recent_head_sha} onto #{@pr.base.ref} #{most_recent_base_sha}"
+        debug_message "Trying merge #{repo}:PR##{pull_request.number} \" #{pull_request.title}\" #{most_recent_head_sha} onto #{pull_request.base.ref} #{most_recent_base_sha}"
 
         if forked_repo_branch_pr?
-          contributor_repo="git://github.com/#{pr.head.repo.full_name}"
+          contributor_repo = "git://github.com/#{pull_request.head.repo.full_name}"
           debug_message("Forked branch pr contributor REPO: #{contributor_repo}")
-          remotes=git.remotes.collect{|r| r.name }
-          unless remotes.include?("contributor")
+          unless git.remotes.any? { |r| r.name == 'contributor' }
             git.add_remote("contributor", contributor_repo)
           end
           git.fetch("contributor")
-          merge_result = git.remote("contributor").merge(pr.head.ref)
+          merge_result = git.remote("contributor").merge(pull_request.head.ref)
         else
           merge_result = git.merge(most_recent_head_sha)
         end
 
-        load_thumbs_config
-        status[:ended_at]=DateTime.now
-        status[:result]=:ok
-        status[:message]="Merge Success: #{@pr.head.ref} #{most_recent_head_sha} onto target branch: #{@pr.base.ref} #{most_recent_base_sha}"
-        status[:output]= "#{merge_result}"
+        status[:ended_at] = DateTime.now
+        status[:result] = :ok
+        status[:message] = "Merge Success: #{pull_request.head.ref} #{most_recent_head_sha} onto target branch: #{pull_request.base.ref} #{most_recent_base_sha}"
+        status[:output] = "#{merge_result}"
       rescue => e
-        debug_message "Merge Failed: #{@pr.head.ref} #{most_recent_head_sha} onto target branch: #{@pr.base.ref} #{most_recent_base_sha}"
-        debug_message "PR ##{@pr[:number]} END"
+        debug_message "Merge Failed: #{pull_request.head.ref} #{most_recent_head_sha} onto target branch: #{pull_request.base.ref} #{most_recent_base_sha}"
+        debug_message "PR ##{pull_request[:number]} END"
 
-        status[:result]=:error
-        status[:message]="Merge Failed: #{@pr.head.ref} #{most_recent_head_sha} onto target branch: #{@pr.base.ref} #{most_recent_base_sha}"
-        status[:output]=e.inspect
+        status[:result] = :error
+        status[:message] = "Merge Failed: #{pull_request.head.ref} #{most_recent_head_sha} onto target branch: #{pull_request.base.ref} #{most_recent_base_sha}"
+        status[:output] = e.inspect
       end
 
-      @build_status[:steps][:merge]=status
+      build_status[:steps][:merge] = status
       status
     end
 
     def run_command_in_docker(command)
-      image=thumb_config['docker_image']||'ubuntu'
-      shell=thumb_config['shell']||'/bin/bash'
+      image = config_docker_image
+      shell = config_shell
       command = "source /etc/bash.bashrc; #{command}"
-      docker_command="sudo docker run -t"
-      (thumb_config['env']||{}).each do |variable_key, variable_value|
+      docker_command = "sudo docker run -t"
+      (config_env).each do |variable_key, variable_value|
         docker_command << " -e #{variable_key}=#{variable_value}"
       end
       docker_command << " -v ~/.bashrc:/etc/bash.bashrc -v /tmp/thumbs:/tmp/thumbs"
@@ -130,7 +147,7 @@ module Thumbs
     end
 
     def run_command_in_shell(command)
-      shell=thumb_config['shell']||'/bin/bash'
+      shell = config_shell
 
       output, exit_code = nil
 
@@ -138,15 +155,15 @@ module Thumbs
         stdin.puts "source ~/.bashrc"
         stdin.puts "#{command} 2>&1"
         stdin.close
-        pid = wait_thr.pid
-        output=stdout_and_stderr.read
+        wait_thr.pid
+        output = stdout_and_stderr.read
         exit_code = wait_thr.value.exitstatus
       end
       [output, exit_code]
     end
 
     def run_command(command)
-      if thumb_config['docker']
+      if config_docker?
         run_command_in_docker(command)
       else
         run_command_in_shell(command)
@@ -154,26 +171,26 @@ module Thumbs
     end
 
     def try_run_build_step(name, command)
-      status={}
+      status = {}
 
-      command = "cd #{@build_dir}; #{command}"
+      command = "cd #{build_dir}; #{command}"
 
       debug_message "running command #{command}"
 
-      status[:started_at]=DateTime.now
+      status[:started_at] = DateTime.now
       status[:command] = command
-      status[:env]=(thumb_config.key?('env') ? thumb_config['env'] : {})
+      status[:env] = config_env
 
       status[:env].each do |key, value|
-        ENV[key]="#{value}"
+        ENV[key] = "#{value}"
       end
       begin
-        Timeout::timeout(thumb_config['timeout']) do
+        Timeout::timeout(config_timeout) do
           output, exit_code = run_command(command)
           unless output && output.strip != ""
             output = "No output"
           end
-          status[:ended_at]=DateTime.now
+          status[:ended_at] = DateTime.now
           unless exit_code == 0
             result = :error
             message = "Step #{name} Failed!"
@@ -187,45 +204,62 @@ module Thumbs
           status[:output] = sanitize_text(output)
           status[:exit_code] = exit_code.to_i
 
-          @build_status[:steps][name.to_sym]=status
+          build_status[:steps][name.to_sym] = status
           debug_message "[ #{name.upcase} ] [#{result.upcase}] \"#{command}\""
           return status
         end
 
       rescue Timeout::Error => e
-        status[:ended_at]=DateTime.now
+        status[:ended_at] = DateTime.now
         status[:result] = :error
-        status[:message] = "Timeout reached (#{@timeout} seconds)"
+        status[:message] = "Timeout reached (#{config_timeout} seconds)"
         status[:output] = e
 
-        @build_status[:steps][name.to_sym]=status
+        build_status[:steps][name.to_sym] = status
         debug_message "[ #{name.upcase} ] [ERROR] \"#{command}\" #{e}"
         return status
       end
     end
 
     def events
-      client.repository_events(@repo).collect { |e| e.to_h }
+      @events ||= octokit_client.repository_events(repo).collect { |e| e.to_h }
     end
 
-    def push_time_stamp(sha)
-      time_stamp=events.collect { |e| e[:created_at] if e[:type] == 'PushEvent' && e[:payload][:head] == sha }.compact.first
-      time_stamp ? time_stamp : pr.created_at
+    def push_timestamp(sha)
+      push_event = events.detect { |e| e[:payload][:head] == sha &&
+                                  e[:type] == 'PushEvent' }
+      timestamp = event_timestamp(push_event)
+      timestamp || pull_request.created_at
     end
 
-    def comments_after_most_recent_commit
-      comments_after_sha=all_comments.compact.collect do |c|
-        comment_timestamp=DateTime.parse(c[:created_at].to_s)
-        c.to_h if comment_timestamp > most_recent_commit_timestamp
-      end.compact
+    def to_timestamp(value)
+      DateTime.parse(value.to_s)
+    end
+
+    def event_timestamp(event)
+      return unless event
+      to_timestamp(event[:created_at])
+    end
+
+    def comment_timestamp(comment)
+      to_timestamp(comment[:created_at])
+    end
+
+    def comments_since_most_recent_commit
+        @comments_since_most_recent_commit ||=
+        all_comments.compact.select { |c|
+          config_comments_since_disabled? ||
+          comment_timestamp(c) > most_recent_commit_timestamp
+        }.map { |c| c.to_h }.compact
     end
 
     def all_comments
-      client.issue_comments(repo, pr.number, per_page: 100)
+      # TODO: allow for paging over all_comments
+      octokit_client.issue_comments(repo, pull_request.number, per_page: 100)
     end
 
     def comments
-      comments_after_most_recent_commit
+      comments_since_most_recent_commit
     end
 
     def bot_comments
@@ -237,20 +271,24 @@ module Thumbs
     end
 
     def non_author_comments
-      comments.collect { |comment| comment if @pr[:user][:login] != comment[:user][:login] && !["thumbot"].include?(comment[:user][:login]) }.compact
+      comments.select { |comment| pull_request[:user][:login] != comment[:user][:login] &&
+                        !["thumbot"].include?(comment[:user][:login]) }.compact
     end
 
     def repo_is_org?
+      return @repo_is_org if @repo_is_org
       begin
-        org_result=client.organization(org)
-      rescue  Octokit::NotFound => e
-
+        org_result = octokit_client.organization(org)
+      rescue  Octokit::NotFound
+        return false
       end
-     org_result && org_result.key?(:id) ? true : false
+      @repo_is_org = org_result && org_result.key?(:id) ? true : false
     end
 
     def org_member?(user_login)
-      client.organization_member?(org, user_login)
+      @org_members ||= {}
+      @org_members[user_login] ||=
+          octokit_client.organization_member?(org, user_login)
     end
 
     def org_member_comments
@@ -266,25 +304,24 @@ module Thumbs
     end
 
     def review_count
-      approval_logins=approvals.collect { |a| a["author"]["login"] }.uniq
-      comment_code_approval_logins=comment_code_approvals.collect { |r| r[:user][:login] }.uniq
+      approval_logins = approvals.collect { |a| a["author"]["login"] }.uniq
+      comment_code_approval_logins = comment_code_approvals.collect { |r| r[:user][:login] }.uniq
       countable_reviews = (approval_logins + comment_code_approval_logins).uniq
       countable_reviews.length
     end
 
-    def reviews
-      (approvals + comment_code_approvals).compact
+    def logger
+      @logger ||= Log4r::Logger['Thumbs']
     end
 
     def debug_message(message)
-      log = Log4r::Logger['Thumbs']
-      if log
-        log.debug("#{@repo} #{@pr.number} #{@pr.state} #{message}")
-      end
+      logger && logger.respond_to?(:debug) &&
+          logger.debug("#{repo} #{pull_request.number} #{pull_request.state} #{message}")
     end
 
     def error_message(message)
-      $logger.respond_to?(:error) ? $logger.error("#{message}") : ""
+      logger && logger.respond_to?(:error) &&
+          logger.error("#{message}")
     end
 
     def valid_for_merge?
@@ -302,45 +339,45 @@ module Thumbs
         return false
       end
 
-      unless @build_status.key?(:steps)
+      unless build_status.key?(:steps)
         debug_message "contains no steps"
         return false
       end
-      unless @build_status[:steps].key?(:merge)
+      unless build_status[:steps].key?(:merge)
         debug_message "contains no merge step"
         return false
       end
-      unless @build_status[:steps].keys.length > 1
-        debug_message "contains no build steps #{@build_status[:steps]}"
+      unless build_status[:steps].keys.length > 1
+        debug_message "contains no build steps #{build_status[:steps]}"
         return false
       end
       debug_message "passed initial"
       debug_message("")
-      @build_status[:steps].each_key do |name|
-        unless @build_status[:steps][name].key?(:result)
+      build_status[:steps].each_key do |name|
+        unless build_status[:steps][name].key?(:result)
           return false
         end
-        unless @build_status[:steps][name][:result]==:ok
+        unless build_status[:steps][name][:result] == :ok
           debug_message "result not :ok, not valid for merge"
           return false
         end
       end
       debug_message "all keys and result ok present"
 
-      unless thumb_config
+      unless thumbs_config_present?
         debug_message "config missing"
         return false
       end
-      unless thumb_config.key?('minimum_reviewers')
+      unless config_minimum_reviewers_present?
         debug_message "minimum_reviewers config option missing"
         return false
       end
-      review_count_value=review_count
-      debug_message "minimum reviewers: #{thumb_config['minimum_reviewers']}"
-      debug_message "review_count: #{review_count_value} >= #{thumb_config['minimum_reviewers']}"
+      review_count_value = review_count
+      debug_message "minimum reviewers: #{config_minimum_reviewers}"
+      debug_message "review_count: #{review_count_value} >= #{config_minimum_reviewers}"
 
-      unless review_count_value >= thumb_config['minimum_reviewers']
-        debug_message " #{review_count_value} !>= #{thumb_config['minimum_reviewers']}"
+      unless review_count_value >= config_minimum_reviewers
+        debug_message " #{review_count_value} !>= #{config_minimum_reviewers}"
         return false
       end
 
@@ -349,7 +386,7 @@ module Thumbs
         return false
       end
 
-      unless thumb_config['merge'] == true
+      unless config_auto_merge?
         debug_message "thumb_config['merge'] != 'true' || thumbs config says: merge: #{thumb_config['merge'].inspect}"
         return false
       end
@@ -382,7 +419,7 @@ module Thumbs
     end
 
     def build_guid
-      "#{pr.base.ref.gsub(/\//, '_')}.#{most_recent_base_sha.slice(0, 7)}.#{pr.head.ref.gsub(/\//, '_')}.#{most_recent_head_sha.slice(0, 7)}"
+      "#{pull_request.base.ref.gsub(/\//, '_')}.#{most_recent_base_sha.slice(0, 7)}.#{pull_request.head.ref.gsub(/\//, '_')}.#{most_recent_head_sha.slice(0, 7)}"
     end
 
     def set_build_progress(progress_status)
@@ -390,11 +427,10 @@ module Thumbs
     end
 
     def compose_build_status_comment_title(progress_status)
-      pr = client.pull_request(repo, @pr.number)
-      status_emoji=(progress_status==:completed ? result_image(aggregate_build_status_result) : result_image(progress_status))
-      comment_title="|||||\n"
-      comment_title<<"------------ | -------------|------------ | ------------- \n"
-      comment_title<<"#{pr.head.ref} #{most_recent_head_sha.slice(0, 7)} | :arrow_right: | #{pr.base.ref} #{most_recent_base_sha.slice(0, 7)} | #{status_emoji} #{progress_status}"
+      status_emoji = (progress_status == :completed ? result_image(aggregate_build_status_result) : result_image(progress_status))
+      comment_title = "|||||\n"
+      comment_title << "------------ | -------------|------------ | ------------- \n"
+      comment_title << "#{pull_request.head.ref} #{most_recent_head_sha.slice(0, 7)} | :arrow_right: | #{pull_request.base.ref} #{most_recent_base_sha.slice(0, 7)} | #{status_emoji} #{progress_status}"
       comment_title
     end
 
@@ -407,30 +443,20 @@ module Thumbs
     end
 
     def get_build_progress_comment
-      bot_comments.collect do |c|
-        next unless c[:body].lines.length > 1
-        status_line = c[:body].lines[2]
-        pr = client.pull_request(repo, @pr.number)
-        next unless status_line =~ /^#{pr.head.ref} #{most_recent_head_sha.slice(0, 7)} \| :arrow_right: \| #{pr.base.ref} #{most_recent_base_sha.slice(0, 7)}/
-        c
-      end.compact[0] || {:body => ""}
-    end
-
-    def comments_after_sha(sha)
-      sha_time_stamp=push_time_stamp(sha)
-      comments_after_sha=all_comments.compact.collect do |c|
-        c.to_h if c[:created_at] > sha_time_stamp
-      end.compact
+      bot_comments.detect { |c|
+        c[:body].lines.length > 1 &&
+        c[:body].lines[2] =~ /^#{pull_request.head.ref} #{most_recent_head_sha.slice(0, 7)} \| :arrow_right: \| #{pull_request.base.ref} #{most_recent_base_sha.slice(0, 7)}/
+      } || {:body => ""}
     end
 
     def update_or_create_build_status(sha, progress_status)
       if build_progress_status == :unstarted
         set_build_status_comment(sha, progress_status)
       else
-        comment=get_build_progress_comment
+        comment = get_build_progress_comment
         comment_id = comment[:id]
         debug_message "comment id is #{comment_id}"
-        comment_message=compose_build_status_comment_title(progress_status)
+        comment_message = compose_build_status_comment_title(progress_status)
         debug_message comment_message
         update_pull_request_comment(comment_id, comment_message)
       end
@@ -438,16 +464,16 @@ module Thumbs
 
     def update_pull_request_comment(comment_id, comment_message)
       begin
-        comment = client.issue_comment(repo, comment_id)
+        comment = octokit_client.issue_comment(repo, comment_id)
         unless comment && comment.key?(:id)
           debug_message "comment doesnt exist"
           return nil
         end
-      rescue Octokit::NotFound => e
+      rescue Octokit::NotFound
         debug_message "comment doesnt exist"
         return nil
       end
-      client.update_comment(repo, comment[:id], comment_message)
+      octokit_client.update_comment(repo, comment[:id], comment_message)
     end
 
     def sanitize_text(text)
@@ -455,13 +481,13 @@ module Thumbs
     end
 
     def create_gist_from_status(name, content)
-      file_title="#{name.to_s.gsub(/\//, '_')}.txt"
-      client.create_gist({:files => {file_title => {:content => content || "no output"}}})
+      file_title = "#{name.to_s.gsub(/\//, '_')}.txt"
+      octokit_client.create_gist({:files => {file_title => {:content => content || "no output"}}})
     end
 
     def clear_build_progress_comment
       build_progress_comment = get_build_progress_comment
-      build_progress_comment ? client.delete_comment(repo, build_progress_comment[:id]) : true
+      build_progress_comment ? octokit_client.delete_comment(repo, build_progress_comment[:id]) : true
     end
 
     def pushes
@@ -474,8 +500,8 @@ module Thumbs
 
     def run_build_steps
       debug_message "begin run_build_steps"
-      build_steps.each do |build_step|
-        build_step_name=build_step.gsub(/\s+/, '_').gsub(/-/, '')
+      config_build_steps.each do |build_step|
+        build_step_name = build_step.gsub(/\s+/, '_').gsub(/-/, '')
         debug_message "run build step #{build_step_name} begin"
         try_run_build_step(build_step_name, build_step)
         debug_message "run build step #{build_step_name} end"
@@ -484,35 +510,38 @@ module Thumbs
       end
     end
 
-    def persist_build_status
-      repo=@repo.gsub(/\//, '_')
-      file=File.join('/tmp/thumbs', "#{repo}_#{build_guid}.yml")
+    def sanitized_repo
+      @sanitized_repo ||= repo.gsub(/\//, '_')
+    end
+
+    def sanitized_build_file
+      return @sanitized_build_file if @sanitized_build_file
       FileUtils.mkdir_p('/tmp/thumbs')
+      @sanitized_build_file =
+        File.join('/tmp/thumbs', "#{sanitized_repo}_#{build_guid}.yml")
+    end
+
+    def persist_build_status
       build_status[:steps].keys.each do |build_step|
         next unless build_status[:steps][build_step].key?(:output)
         output = build_status[:steps][build_step][:output]
         build_status[:steps][build_step][:output] = sanitize_text(output)
       end
-      File.open(file, "w") do |f|
+      File.open(sanitized_build_file, "w") do |f|
         f.syswrite(build_status.to_yaml)
       end
       true
     end
 
     def unpersist_build_status
-      repo=@repo.gsub(/\//, '_')
-      file=File.join('/tmp/thumbs', "#{repo}_#{build_guid}.yml")
-      File.delete(file) if File.exist?(file)
+      File.delete(sanitized_build_file) if File.exist?(sanitized_build_file)
     end
 
     def read_build_status
-      repo=@repo.gsub(/\//, '_')
-      file=File.join('/tmp/thumbs', "#{repo}_#{build_guid}.yml")
-      if File.exist?(file)
+      if File.exist?(sanitized_build_file)
         begin
-          YAML.load(IO.read(file))
-        rescue Psych::SyntaxError => e
-
+          YAML.load(IO.read(sanitized_build_file))
+        rescue Psych::SyntaxError
         end
       else
         {:steps => {}}
@@ -533,67 +562,59 @@ module Thumbs
     end
 
     def merge
-      status={}
-      status[:started_at]=DateTime.now
+      status = {}
+      status[:started_at] = DateTime.now
       if merged?
         debug_message "already merged ? nothing to do here"
-        status[:result]=:error
-        status[:message]="already merged"
-        status[:ended_at]=DateTime.now
+        status[:result] = :error
+        status[:message] = "already merged"
+        status[:ended_at] = DateTime.now
         return status
       end
       unless state == "open"
         debug_message "pr not open"
-        status[:result]=:error
-        status[:message]="pr not open"
-        status[:ended_at]=DateTime.now
+        status[:result] = :error
+        status[:message] = "pr not open"
+        status[:ended_at] = DateTime.now
         return status
       end
       unless mergeable?
         debug_message "no mergeable? nothing to do here"
-        status[:result]=:error
-        status[:message]=".mergeable returns false"
-        status[:ended_at]=DateTime.now
+        status[:result] = :error
+        status[:message] = ".mergeable returns false"
+        status[:ended_at] = DateTime.now
         return status
       end
       unless mergeable_state == "clean"
-
         debug_message ".mergeable_state not clean! "
-        status[:result]=:error
-        status[:message]=".mergeable_state not clean"
-        status[:ended_at]=DateTime.now
+        status[:result] = :error
+        status[:message] = ".mergeable_state not clean"
+        status[:ended_at] = DateTime.now
         return status
       end
 
       # validate config
-      unless thumb_config && thumb_config.key?('build_steps') && thumb_config.key?('minimum_reviewers')
+      unless config_build_steps_present? && config_minimum_reviewers_present?
         debug_message "no usable .thumbs.yml"
-        status[:result]=:error
-        status[:message]="no usable .thumbs.yml"
-        status[:ended_at]=DateTime.now
-        return status
-      end
-      unless thumb_config.key?('minimum_reviewers')
-        debug_message "no minimum reviewers configured"
-        status[:result]=:error
-        status[:message]="no minimum reviewers configured"
-        status[:ended_at]=DateTime.now
+        status[:result] = :error
+        status[:message] = "no usable .thumbs.yml"
+        status[:ended_at] = DateTime.now
         return status
       end
 
-      if thumb_config.key?('merge') == 'false'
+      unless config_auto_merge?
         debug_message ".thumbs.yml config says no merge"
-        status[:result]=:error
-        status[:message]=".thumbs.yml config merge=false"
-        status[:ended_at]=DateTime.now
+        status[:result] = :error
+        status[:message] = ".thumbs.yml config merge=false"
+        status[:ended_at] = DateTime.now
         return status
       end
 
       if wait_lock?
         debug_message "wait_lock? thumbot wait enabled."
-        status[:result]=:error
-        status[:message]="wait_lock? thumbot wait enabled."
-        status[:ended_at]=DateTime.now
+        status[:result] = :error
+        status[:message] = "wait_lock? thumbot wait enabled."
+        status[:ended_at] = DateTime.now
         return status
       end
 
@@ -601,8 +622,8 @@ module Thumbs
         debug_message("Starting github API merge request")
         commit_message = 'Thumbs Git Robot Merge. '
 
-        merge_response = client.merge_pull_request(@repo, @pr.number, commit_message, options = {})
-        merge_comment="Successfully merged *#{@repo}/pulls/#{@pr.number}* (*#{most_recent_head_sha}* on to *#{@pr.base.ref}*)\n\n"
+        octokit_client.merge_pull_request(repo, pull_request.number, commit_message, options: {})
+        merge_comment = "Successfully merged *#{repo}/pulls/#{pull_request.number}* (*#{most_recent_head_sha}* on to *#{pull_request.base.ref}*)\n\n"
         merge_comment << " ```yaml    \n#{merge_response.to_hash.to_yaml}\n ``` \n"
 
         add_comment merge_comment
@@ -612,65 +633,68 @@ module Thumbs
         debug_message log_message
 
         status[:message] = log_message
-        status[:output]=e.inspect
+        status[:output] = e.inspect
       end
-      status[:ended_at]=DateTime.now
+      status[:ended_at] = DateTime.now
 
       debug_message "Merge #END"
       status
     end
 
     def mergeable?
-      client.pull_request(@repo, @pr.number).mergeable
+      pull_request.mergeable
     end
 
     def mergeable_state
-      client.pull_request(@repo, @pr.number).mergeable_state
+      pull_request.mergeable_state
     end
 
     def merged?
-      client.pull_merged?(@repo, @pr.number)
+      octokit_client.pull_merged?(repo, pull_request.number)
     end
 
     def state
-      client.pull_request(@repo, @pr.number).state
+      pull_request.state
     end
 
     def open?
-      debug_message "open?"
-      client.pull_request(@repo, @pr.number).state == "open"
+      state == "open"
     end
 
-    def add_comment(comment, options={})
-      client.add_comment(@repo, @pr.number, comment, options = {})
+    def add_comment(comment, options = {})
+      octokit_client.add_comment(repo, pull_request.number, comment, options = {})
     end
 
     def close
-      client.close_pull_request(@repo, @pr.number)
+      octokit_client.close_pull_request(repo, pull_request.number)
     end
 
     def open_pull_requests
-      client.pull_requests(@repo, :state => 'open')
+      @open_pull_requests ||= octokit_client.pull_requests(repo, :state => 'open')
     end
 
     def commits
-      client.commits(pr.head.repo.full_name, pr.head.ref)
+      @commits ||= octokit_client.commits(pull_request.head.repo.full_name, pull_request.head.ref)
+    end
+
+    def base_commits
+      @base_commits ||= octokit_client.commits(pull_request.base.repo.full_name, pull_request.base.ref)
     end
 
     def most_recent_head_sha
-      client.commits(pr.head.repo.full_name, pr.head.ref).first[:sha]
+      commits.first[:sha]
     end
 
     def most_recent_base_sha
-      client.commits(pr.base.repo.full_name, pr.base.ref).first[:sha]
+      base_commits.first[:sha]
     end
 
     def pull_requests_for_base_branch(branch)
-      open_pull_requests.collect { |pr| pr if pr.base.ref == branch }
+      open_pull_requests.select { |pr| pr.base.ref == branch }
     end
 
     def build_status_problem_steps
-      @build_status[:steps].collect { |step_name, status| step_name if status[:result] != :ok }.compact
+      build_status[:steps].collect { |step_name, status| step_name if status[:result] != :ok }.compact
     end
 
     def aggregate_build_status_result
@@ -684,17 +708,19 @@ module Thumbs
       :ok
     end
 
-    def create_build_status_comment
+    def status_title
       if aggregate_build_status_result == :ok
-        @status_title="\n<details><Summary>Looks good!  :+1: </Summary>"
+        "\n<details><Summary>Looks good!  :+1: </Summary>"
       else
-        @status_title="\n<details><Summary>There seems to be an issue with build step **#{build_status_problem_steps.join(",")}** !  :cloud: </Summary>"
+        "\n<details><Summary>There seems to be an issue with build step **#{build_status_problem_steps.join(",")}** !  :cloud: </Summary>"
       end
+    end
 
+    def create_build_status_comment
       build_comment = render_template <<-EOS
-<% @build_status[:steps].each do |step_name, status| %>
+<% build_status[:steps].each do |step_name, status| %>
 <% if status[:output] %>
-<% gist=create_gist_from_status(step_name, status[:output]) %>
+<% gist = create_gist_from_status(step_name, status[:output]) %>
 <% end %>
 <details>
  <summary><%= result_image(status[:result]) %> <%= step_name.upcase %> </summary>
@@ -715,8 +741,8 @@ module Thumbs
 
 <%= status[:command] %>
 
-<% output=status[:output] %>
-<% allowed_length=10000 %>
+<% output = status[:output] %>
+<% allowed_length = 10000 %>
 <% if output.length > allowed_length %>
   <% snipped_characters = output.length - allowed_length %>
   <% snipped_lines = output.slice(0, output.length-allowed_length).split(/\n/) %>
@@ -734,13 +760,13 @@ module Thumbs
 </details>
 
 <% end %>
-<%= render_reviewers_comment_template if thumb_config %>
+<%= render_reviewers_comment_template if thumbs_config_present? %>
 
 </details>
       EOS
       comment_id = get_build_progress_comment[:id]
       comment_message = compose_build_status_comment_title(:completed)
-      comment_message << "\n#{@status_title}"
+      comment_message << "\n#{status_title}"
       comment_message << build_comment
       if comment_message.length > 65000
         debug_message "comment_message too large : #{comment_message.length} unable to post"
@@ -750,12 +776,12 @@ module Thumbs
     end
 
     def render_reviewers_comment_template
-      comment = render_template <<-EOS
-<% status_code= (review_count >= minimum_reviewers ? :ok : :unchecked) %>
-<% org_msg=  thumb_config['org_mode'] ? " from organization #{repo.split(/\//).shift}"  : "." %>
+      render_template <<-EOS
+<% status_code = (review_count >= config_minimum_reviewers ? :ok : :unchecked) %>
+<% org_msg = config_org_mode ? " from organization #{repo.split(/\//).shift}"  : "." %>
 <details>
-<summary><%= result_image(status_code) %> <%= review_count %> of <%= minimum_reviewers %> Code reviews<%= org_msg %></summary>
-<% reviews.each do |review| %>
+<summary><%= result_image(status_code) %> <%= review_count %> of <%= config_minimum_reviewers %> Code reviews<%= org_msg %></summary>
+<% effective_approvals.each do |review| %>
   <% if review.key?(:user) && review[:user].key?(:login) %>
   - @<%= review[:user][:login] %>: <%= review[:body] %> 
   <% end %>
@@ -764,7 +790,7 @@ module Thumbs
   <% end %>
 <% end %>
 </details>
-      EOS
+EOS
     end
 
     def create_reviewers_comment
@@ -772,119 +798,163 @@ module Thumbs
       add_comment(comment)
     end
 
-    def load_thumbs_config
-      thumb_file = File.join(@build_dir, ".thumbs.yml")
-      unless File.exist?(thumb_file)
+    def thumbs_config_path
+      File.join(build_dir, ".thumbs.yml")
+    end
+
+    def thumbs_config
+      return @thumbs_config if @thumbs_config
+      unless thumbs_config_present?
         debug_message "\".thumbs.yml\" config file not found"
-        return false
+        return thumbs_config_default
       end
       begin
-        @thumb_config=YAML.load(IO.read(thumb_file))
-        @build_steps=@thumb_config['build_steps']
-        @minimum_reviewers=@thumb_config['minimum_reviewers']
-        @auto_merge=@thumb_config['merge']
-        @timeout=@thumb_config['timeout']
-        debug_message "\".thumbs.yml\" config file Loaded: #{@thumb_config.to_yaml}"
-      rescue => e
+        @thumbs_config = YAML.load(IO.read(thumbs_config_path))
+        debug_message "\".thumbs.yml\" config file Loaded: #{thumbs_config.to_yaml}"
+      rescue
         error_message "thumbs config file loading failed"
-        return nil
+        return thumbs_config_default
       end
-      @thumb_config
+      @thumbs_config
+    end
+ 
+    def thumbs_config_present?
+      File.exist?(thumbs_config_path)
     end
 
-    def get_open_pull_requests_for_repo
-      org, repo_name = @repo.split('/')
-      GitHub::Client.parse <<-GRAPHQL
-        query {
-          repositoryOwner(login: "#{org}"){
-            repository(name: "#{repo_name}") {
-              pullRequests(states:OPEN, last: 2) {
-                edges {
-                  node{
-                    id
-                    number
-                  }
-                }
-              }
-            }
-          }
-        }
-      GRAPHQL
+    def config_value(key, default = nil)
+      config = thumbs_config
+      config && config[key] || default
     end
 
-    def get_pull_request_id
-      prs_for_repo_query=get_open_pull_requests_for_repo
-      pr_list=run_graph_query(prs_for_repo_query).data.to_h
-      unless pr_list.key?('repositoryOwner') && pr_list['repositoryOwner'].key?('repository')
-        debug_message("pr_list does not contain repositoryOwner and repository key: #{pr_list}")
-        return nil
-      end
-
-      graph_repo=pr_list['repositoryOwner']['repository']
-      my_pull_request_id=graph_repo['pullRequests']['edges'].collect do |n|
-        next unless n.key?('node')
-        next unless n['node'].key?('id')
-        next unless n['node']['number'].to_i == @pr.number.to_i
-        n['node']['id']
-      end.compact.first
-      debug_message "my pull request id: #{my_pull_request_id}"
-      my_pull_request_id
+    def config_value_set(key, value)
+      config = thumbs_config
+      config && config[key] = value
     end
 
-    def get_pull_request_by_id(id)
-      GitHub::Client.parse <<-GRAPHQL
-   query {
-    node(id: "#{id}") {
-      ... on PullRequest {
-          id
-          number
-          reviews(last:10) {
-            edges {
-              node {
-                author {
-                  id
-                  name
-                  login
-                }
-                body                 
-                state
-                submittedAt
-              }
-            }
-          }
-        }
-      }
-   }
-      GRAPHQL
+    def config_key_present?(key)
+      config = thumbs_config
+      config && config.key?(key)
+    end
+
+    def config_build_steps
+      config_value('build_steps',  [])
+    end
+
+    def config_build_steps_present?
+      config_key_present?('build_steps')
+    end
+
+    def config_minimum_reviewers
+      config_value('minimum_reviewers', 2)
+    end
+ 
+    def config_minimum_reviewers_set(value)
+      config_value_set('minimum_reviewers', value)
+    end
+
+    def config_minimum_reviewers_present?
+      config_key_present?('minimum_reviewers')
+    end
+
+    def config_auto_merge_set(value)
+      config_value_set('merge', value)
+    end
+
+    def config_auto_merge?
+      config_value('merge', false)
+    end
+
+    def config_auto_merge_present?
+      config_key_present?('merge')
+    end
+
+    def config_timeout
+      config_value('timeout', 1800)
+    end
+
+    def config_org_mode
+      config_value('org_mode', true)
+    end
+
+    def config_docker_image
+      config_value('docker_image', 'ubuntu')
+    end
+
+    def config_shell
+      config_value('shell', '/bin/bash')
+    end
+
+    def config_env
+      config_value('env', {})
+    end
+
+    def config_docker?
+      config_value('docker', false)
+    end
+
+    def config_comments_since_disabled?
+      config_value('comments_since_disabled', false)
+    end
+
+    def config_comments_since_disabled_set(value)
+      @comments_since_most_recent_commit = nil
+      config_value_set('comments_since_disabled', value)
+    end
+
+    def commit_not_thumbs?(commit)
+      commit[:commit][:author][:name] != 'Thumbs'
+    end
+
+    def head_commits
+      @head_commits ||= octokit_client.commits(pull_request.head.repo.full_name, pull_request.head.ref)
+    end
+
+    def base_commits
+      @base_commits ||= octokit_client.commits(pull_request.base.repo.full_name, pull_request.base.ref)
+    end
+
+    def commit_timestamp(commit)
+      to_timestamp(commit[:commit][:committer][:date])
+    end
+
+    def most_recent_commit
+      return @most_recent_commit if @most_recent_commit
+      head_commit = head_commits.detect {|c| commit_not_thumbs?(c) }
+      base_commit = base_commits.detect {|c| commit_not_thumbs?(c) }
+
+      head_commit_timestamp = commit_timestamp(head_commit)
+      base_commit_timestamp = commit_timestamp(base_commit)
+      @most_recent_commit =
+          head_commit_timestamp > base_commit_timestamp ?
+            head_commit : base_commit
     end
 
     def most_recent_commit_timestamp
-      head_commits=client.commits(pr.head.repo.full_name, pr.head.ref)
-      base_commits=client.commits(pr.base.repo.full_name, pr.base.ref)
-      head_commit_timestamp = DateTime.parse(head_commits.first[:commit][:committer][:date].to_s)
-      base_commit_timestamp = DateTime.parse(base_commits.first[:commit][:committer][:date].to_s)
-      head_commit_timestamp > base_commit_timestamp ? head_commit_timestamp : base_commit_timestamp
+      commit_timestamp(most_recent_commit)
     end
 
-    def get_approvals(id)
-      approval_entries=get_reviews_by_pr_id(id).collect { |r| r if r['state'] == 'APPROVED' }.compact
-      approval_entries=approval_entries.collect do |a|
-        approval_timestamp_int=DateTime.parse(a['submittedAt'])
-        a if approval_timestamp_int > most_recent_commit_timestamp
-      end
-      approval_entries.compact
+    def effective_approvals
+      (approvals + comment_code_approvals).compact
     end
 
     def any_member_approvals
-      get_approvals(pull_request_id)
+      reviews.select { |r| r['state'] == 'APPROVED' }.
+        select { |a| to_timestamp(a['submittedAt']) > most_recent_commit_timestamp }.
+        compact
     end
 
     def org_member_approvals
-      any_member_approvals.collect { |approval| approval if @client.organization_member?(org, approval["author"]["login"]) }.compact
+      approval_members = any_member_approvals.map { |a| a['author']['login'] }.uniq
+      approval_members = approval_members.map {|u| [u, octokit_client.organization_member?(org, u)] }.to_h
+
+      any_member_approvals.select { |approval|
+        approval_members[approval["author"]["login"]]
+      }.compact
     end
 
     def approvals
-      if thumb_config.key?('org_mode') && thumb_config['org_mode']
+      if config_org_mode
         debug_message "returning org_member_code_approvals"
         return org_member_approvals
       end
@@ -892,38 +962,70 @@ module Thumbs
     end
 
     def approval_count
-      approvals.collect { |a| a["author"]["login"] }.uniq.length
+      approvals.map { |a| a["author"]["login"] }.uniq.length
     end
 
     def comment_code_approval_count
-      comment_code_approvals.collect { |r| r[:user][:login] }.uniq.length
+      comment_code_approvals.map { |r| r[:user][:login] }.uniq.length
     end
 
-    def get_reviews_by_pr_id(id)
-      pr_hash = run_graph_query(get_pull_request_by_id(id)).data.to_h['node']
-      pr_hash ? (pr_hash.key?('reviews') ? pr_hash['reviews']['edges'].collect { |e| e['node'] } : []) : []
+    def reviews_query(pr_id)
+      GitHub::Client.parse <<-GRAPHQL
+query {
+  node(id: "#{pr_id}") {
+    ... on PullRequest {
+      id
+      number
+      reviews(last:10) {
+        edges {
+          node {
+            author {
+              id
+              name
+              login
+            }
+            body
+            state
+            submittedAt
+          }
+        }
+      }
+    }
+  }
+}
+      GRAPHQL
+    end
+
+    def reviews
+      return @reviews if @reviews
+      query = reviews_query(pull_request.id)
+      pr_hash = run_graph_query(query).data.to_h['node']
+      if pr_hash && pr_hash.key?('reviews')
+        @revies = pr_hash['reviews']['edges'].collect { |e| e['node'] }
+      else
+        @reviews = []
+      end
     end
 
     def run_graph_query(query)
       debug_message "running graph query #{query}"
-      result=GitHub::Client.query query
+      result = GitHub::Client.query query
       debug_message "graph query result #{result}"
       result
     end
 
     def comment_code_approvals
-      if @thumb_config['org_mode']
+      if config_org_mode
         debug_message "returning org_member_code_reviews"
         return org_member_code_reviews
       end
-
       code_reviews
     end
 
     def parse_thumbot_command(text_body)
       result_lines = text_body.split(/\n/).grep(/^thumbot/)
       return nil unless result_lines.length > 0
-      command_string=result_lines.shift
+      command_string = result_lines.shift
       command_elements = command_string.split(/\s+/)
       return nil unless command_elements.length > 1
       command = command_elements[1].to_sym
@@ -932,7 +1034,7 @@ module Thumbs
     end
 
     def contains_thumbot_command?(text_body)
-      command=parse_thumbot_command(text_body)
+      command = parse_thumbot_command(text_body)
       command ? true : false
     end
 
@@ -955,11 +1057,11 @@ module Thumbs
       debug_message "received merge command"
       validate
 
-      unless thumb_config
+      unless thumbs_config_present?
         add_comment "Sorry, can't merge without a .thumbs.yml in the branch"
         return false
       end
-      @thumb_config['merge'] = true
+      config_auto_merge_set(true)
       return false unless valid_for_merge?
       create_reviewers_comment
       add_comment "Merging and closing this pr"
@@ -968,9 +1070,15 @@ module Thumbs
     end
 
     def forked_repo_branch_pr?
-      debug_message "pr.base.repo.full_name #{pr.base.repo.full_name}"
-      debug_message "pr.head.repo.full_name #{pr.head.repo.full_name}"
-      pr.base.repo.full_name != pr.head.repo.full_name ? true : false
+      debug_message "pull_request.base.repo.full_name #{pull_request.base.repo.full_name}"
+      debug_message "pull_request.head.repo.full_name #{pull_request.head.repo.full_name}"
+      pull_request.base.repo.full_name != pull_request.head.repo.full_name
+    end
+
+    def inspect
+      prefix = "#<#{self.class}:0x#{self.__id__.to_s(16)}"
+      suffix = ">"
+      "#{prefix} @repo=#{repo}, @pr=#{pr}, @build_dir=#{build_dir}#{suffix}"
     end
 
     def wait_lock?
@@ -998,6 +1106,16 @@ module Thumbs
         else
           ""
       end
+    end
+
+    def parse_github_pr_url(url)
+      matches = github_pr_url_re.match(url)
+      return if matches.nil?
+      return "#{matches[4]}/#{matches[5]}", matches[6].to_i
+    end
+
+    def github_pr_url_re()
+      /(http[s]?[:][\/]+)(([^\/]+.)?[^\/]+\.[^\/]+)\/([^\/]+)\/([^\/]+)\/pull\/([0-9]+)/
     end
   end
 end

--- a/test/test_code_approvals.rb
+++ b/test/test_code_approvals.rb
@@ -1,16 +1,4 @@
 unit_tests do
-
-  test "should  respond to get_pull_request_by_id" do
-    default_vcr_state do
-      assert PRW.respond_to?(:get_pull_request_by_id)
-    end
-  end
-  test "should  respond to get_reviews_by_pr_id" do
-    default_vcr_state do
-      assert PRW.respond_to?(:get_reviews_by_pr_id)
-    end
-  end
-
   test "should  respond to run_graph_query" do
     default_vcr_state do
       assert PRW.respond_to?(:run_graph_query)
@@ -21,19 +9,6 @@ unit_tests do
     default_vcr_state do
       assert PRW.respond_to?(:approvals)
       assert PRW.approvals.length == 0
-      cassette(:get_pull_request_id) do
-        assert_equal PRW.get_approvals(PRW.pull_request_id), PRW.approvals
-      end
-    end
-  end
-
-  test "should  respond to get_approvals" do
-    default_vcr_state do
-      assert PRW.respond_to?(:get_approvals)
-      assert PRW.approvals.length == 0
-      code_reviews = PRW.get_reviews_by_pr_id(PRW.pull_request_id)
-      approvals_by_pr_id=code_reviews.collect{|r| r if r['state'] == 'APPROVED'}.compact
-      assert_equal approvals_by_pr_id, PRW.get_approvals(PRW.pull_request_id)
     end
   end
 

--- a/test/test_docker.rb
+++ b/test/test_docker.rb
@@ -7,6 +7,7 @@ unit_tests do
       assert_equal 0, exit_code
     end
   end
+
   test "can run command in docker" do
     docker_test_command="grep docker /proc/1/cgroup"
     cassette(:get_commits, :record => :new_episodes) do
@@ -14,44 +15,38 @@ unit_tests do
 
         PRW.try_merge
         unless ENV['_system_version']
-          output, exit_code= PRW.run_command_in_shell(docker_test_command)
-          assert_equal "", output
+          output, exit_code = PRW.run_command_in_shell(docker_test_command)
           assert 0 != exit_code
         end
 
         cassette(:run_docker_command1, :record => :all) do
-
           PRW.respond_to?(:run_command_in_docker)
           output, exit_code= PRW.run_command_in_docker(docker_test_command)
-          assert output =~ /systemd\:\/docker\//
           assert_equal 0, exit_code
+          assert output =~ /systemd\:\/docker\//
         end
       end
-
     end
   end
 
 
   test "can detect docker in config and run command in docker." do
     docker_test_command="grep docker /proc/1/cgroup"
-
     cassette(:run_docker_command, :record => :all) do
       cassette(:run_docker_command1, :record => :all) do
 
         PRW.try_merge
 
-        PRW.thumb_config['docker']=false
+        PRW.thumbs_config['docker'] = false
         unless ENV['_system_version']
           output, exit_code = PRW.run_command(docker_test_command)
-          assert_equal "", output
           assert 0 != exit_code
         end
 
-        PRW.thumb_config['docker']=true
-
+        PRW.thumbs_config['docker'] = true
         output, exit_code= PRW.run_command(docker_test_command)
-        assert output =~ /systemd\:\/docker\//, output
         assert_equal 0, exit_code
+        assert output =~ /systemd\:\/docker\//, output
       end
 
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -72,7 +72,7 @@ def create_test_pr(repo_name)
   client1 = Octokit::Client.new(:netrc => true)
   cassette(:create_pull_request, :record => :all) do
     pr = client1.create_pull_request(repo_name, "master", pr_branch, "Testing PR", "Thumbs Git Robot: This pr has been created for testing purposes")
-    prw=Thumbs::PullRequestWorker.new(:repo => repo_name, :pr => pr.number)
+    prw=Thumbs::PullRequestWorker.new(:repo => repo_name, :pr => pr)
     return prw
   end
 end

--- a/test/test_persisted_build_status.rb
+++ b/test/test_persisted_build_status.rb
@@ -7,7 +7,7 @@ unit_tests do
           cassette(:get_commits_for_branch, :record => :new_episodes) do
             PRW.reset_build_status
             PRW.unpersist_build_status
-            PRW.build_steps=["make", "make test"]
+            PRW.thumbs_config['build_steps'] = ["make", "make test"]
             PRW.run_build_steps
             PRW.try_merge
             PRW.persist_build_status
@@ -54,7 +54,7 @@ unit_tests do
       cassette(:load_pr) do
         cassette(:get_events_reload, :record => :new_episodes) do
           cassette(:get_events_reload2, :record => :new_episodes) do
-            PRW.build_steps=["make"]
+            PRW.thumbs_config['build_steps'] = ["make"]
             PRW.run_build_steps
             PRW.persist_build_status
             status = PRW.read_build_status
@@ -72,15 +72,15 @@ unit_tests do
   test "should fix bad utf8 byte sequence" do
     bad_test_string="hi \255"
     assert_raise(ArgumentError) do
-      test_split = bad_test_string.split(' ')
+      bad_test_string.split(' ')
     end
 
     fixed_bad_test_string=sanitize_text(bad_test_string)
-    test_split = fixed_bad_test_string.split(' ')
+    fixed_bad_test_string.split(' ')
     default_vcr_state do
       cassette(:load_pr) do
         cassette(:get_events_reload, :record => :new_episodes) do
-          PRW.build_steps=["make"]
+          PRW.thumbs_config['build_steps'] = ["make"]
           PRW.run_build_steps
           PRW.build_status[:steps][:make][:output]=bad_test_string
 

--- a/test/test_state.rb
+++ b/test/test_state.rb
@@ -17,7 +17,7 @@ unit_tests do
 
   test "can get most_recent_sha" do
     default_vcr_state do
-      assert_equal PRW.pr.head.sha, PRW.most_recent_sha
+      assert_equal PRW.pull_request.head.sha, PRW.most_recent_sha
     end
   end
 end

--- a/test/test_webhook.rb
+++ b/test/test_webhook.rb
@@ -20,9 +20,9 @@ class WebhookTest < Test::Unit::TestCase
   def test_can_get_pr
     cassette(:graphql) do
       cassette(:get_basic_pr) do
-        assert_equal "thumbot/prtester", PRW.pr.base.repo.full_name
+        assert_equal "thumbot/prtester", PRW.pull_request.base.repo.full_name
         assert_equal "thumbot/prtester", PRW.repo
-        assert_equal TESTPR, PRW.pr.number
+        assert_equal TESTPR, PRW.pr
       end
     end
   end
@@ -59,7 +59,7 @@ class WebhookTest < Test::Unit::TestCase
               }
           },
           'repository' => {'full_name' => PRW.repo},
-          'pull_request' => {'number' => PRW.pr.number, 'body' => PRW.pr.body}
+          'pull_request' => {'number' => PRW.pr, 'body' => PRW.pull_request.body}
       }
       cassette(:get_comments, :record => :all) do
         cassette(:get_issue_comments, :record => :new_episodes) do
@@ -118,17 +118,17 @@ class WebhookTest < Test::Unit::TestCase
 
       new_pr_webhook_payload = {
           'repository' => {'full_name' => PRW.repo},
-          'number' => PRW.pr.number,
-          'pull_request' => {'number' => PRW.pr.number, 'body' => PRW.pr.body}
+          'number' => PRW.pr,
+          'pull_request' => {'number' => PRW.pr, 'body' => PRW.pull_request.body}
       }
       PRW.unpersist_build_status
       PRW.reset_build_status
       PRW.unpersist_build_status
-      PRW.build_steps=["make", "make test"]
+      PRW.thumbs_config['build_steps'] = ["make", "make test"]
       PRW.try_merge
       assert PRW.build_status[:steps].keys.length == 1, PRW.build_status[:steps].inspect
       assert PRW.build_status[:steps].key?(:merge)
-      remove_comments(PRW.repo, PRW.pr.number)
+      remove_comments(PRW.repo, PRW.pr)
       cassette(:get_comments, :record => :all) do
         cassette(:get_issue_comments, :record => :all) do
 
@@ -148,12 +148,12 @@ class WebhookTest < Test::Unit::TestCase
 
       new_approval_webhook_payload = {
           'repository' => {'full_name' => PRW.repo},
-          'number' => PRW.pr.number,
-          'pull_request' => {'number' => PRW.pr.number, 'body' => PRW.pr.body}
+          'number' => PRW.pr,
+          'pull_request' => {'number' => PRW.pr, 'body' => PRW.pull_request.body}
       }
       PRW.unpersist_build_status
 
-      remove_comments(PRW.repo, PRW.pr.number)
+      remove_comments(PRW.repo, PRW.pr)
       cassette(:get_comments, :record => :all) do
         cassette(:get_issue_comments, :record => :all) do
 
@@ -178,10 +178,10 @@ class WebhookTest < Test::Unit::TestCase
           'comment' => {'body' => 'thumbot merge',
                         'user' => {'login' => 'bob' },
                         },
-          'issue' => {'number' => PRW.pr.number},
+          'issue' => {'number' => PRW.pr},
           'repository' => {'full_name' => PRW.repo},
-          'number' => PRW.pr.number,
-          'pull_request' => {'number' => PRW.pr.number}
+          'number' => PRW.pr,
+          'pull_request' => {'number' => PRW.pr}
       }
 
       post '/webhook', merge_command_webhook_payload.to_json do
@@ -193,10 +193,10 @@ class WebhookTest < Test::Unit::TestCase
           'comment' => {'body' => 'thumbot merge',
                         'user' => {'login' => 'davidx' },
           },
-          'issue' => {'number' => PRW.pr.number},
+          'issue' => {'number' => PRW.pr},
           'repository' => {'full_name' => PRW.repo},
-          'number' => PRW.pr.number,
-          'pull_request' => {'number' => PRW.pr.number}
+          'number' => PRW.pr,
+          'pull_request' => {'number' => PRW.pr}
       }
 
       post '/webhook', merge_command_webhook_payload.to_json do


### PR DESCRIPTION
WIP - `test/test_build_steps.rb` test "should not merge if merge false in thumbs." is failing on this branch, but not on master.

* changed Thumbs::PullRequestWorker.comments_since_most_recent_commit to exclude thumbs (merge) commits, see most_recent_commit.
* massively refactored Thumbs::PullRequestWorker to employ lazy loading (@var ||=) as much as was pragmatic.
* refactored Thumbs::PullRequestWorker to start to gather like methods together for extraction into a class, i.e. config_* for thumbs_config.
* addressed automatic code review suggestions, such as removing unused variables and whitespace.
* removed unused methods.