### PR TITLE
Clear build dir on thumbot retry

### DIFF
--- a/lib/thumbs/pull_request_worker.rb
+++ b/lib/thumbs/pull_request_worker.rb
@@ -920,6 +920,10 @@ module Thumbs
       code_reviews
     end
 
+    def remove_build_dir
+      FileUtils.mv(@build_dir, "#{@build_dir}.0")
+    end
+
     def parse_thumbot_command(text_body)
       result_lines = text_body.split(/\n/).grep(/^thumbot/)
       return nil unless result_lines.length > 0
@@ -943,6 +947,7 @@ module Thumbs
     def thumbot_retry
       debug_message "received retry command"
       unpersist_build_status
+      remove_build_dir
       set_build_progress(:in_progress)
       validate
       set_build_progress(:completed)

--- a/lib/thumbs/pull_request_worker.rb
+++ b/lib/thumbs/pull_request_worker.rb
@@ -921,7 +921,7 @@ module Thumbs
     end
 
     def remove_build_dir
-      FileUtils.mv(@build_dir, "#{@build_dir}.0")
+      FileUtils.mv(@build_dir, "#{@build_dir}.#{DateTime.now.strftime("%s")}")
     end
 
     def parse_thumbot_command(text_body)

--- a/lib/thumbs/pull_request_worker.rb
+++ b/lib/thumbs/pull_request_worker.rb
@@ -948,6 +948,7 @@ module Thumbs
       debug_message "received retry command"
       unpersist_build_status
       remove_build_dir
+      clear_build_progress_comment
       set_build_progress(:in_progress)
       validate
       set_build_progress(:completed)


### PR DESCRIPTION
This blows away the build directory during a retry so that a completely fresh state can be attained. 
For potential forensics, the build dir will actually be moved to a backup directory, to be truncated from disk at a later time.
This pr also adds behavior that instead of updating the existing build status, it now creates a new build status comment and removes the old one. 

example: https://github.com/davidx/prtester/pull/330