### PR TITLE
Merge method

### DIFF
--- a/lib/thumbs/pull_request_worker.rb
+++ b/lib/thumbs/pull_request_worker.rb
@@ -600,8 +600,9 @@ module Thumbs
       begin
         debug_message("Starting github API merge request")
         commit_message = 'Thumbs Git Robot Merge. '
-
-        merge_response = client.merge_pull_request(@repo, @pr.number, commit_message, options = {})
+        merge_method = thumb_config['merge_method'] && ["merge", "squash", "rebase"].include?(thumb_config['merge_method']) ? thumb_config['merge_method'] :  "merge"
+        merge_options = { merge_method:  merge_method, accept: "application/vnd.github.polaris-preview+json" }
+        merge_response = client.merge_pull_request(@repo, @pr.number, commit_message, merge_options)
         merge_comment="Successfully merged *#{@repo}/pulls/#{@pr.number}* (*#{most_recent_head_sha}* on to *#{@pr.base.ref}*)\n\n"
         merge_comment << " ```yaml    \n#{merge_response.to_hash.to_yaml}\n ``` \n"
 

--- a/lib/thumbs/pull_request_worker.rb
+++ b/lib/thumbs/pull_request_worker.rb
@@ -600,7 +600,7 @@ module Thumbs
       begin
         debug_message("Starting github API merge request")
         commit_message = 'Thumbs Git Robot Merge. '
-        merge_method = thumb_config['merge_method'] && ["merge", "squash", "rebase"].include?(thumb_config['merge_method']) ? thumb_config['merge_method'] :  "merge"
+        merge_method = thumb_config['merge_method'] && ["merge", "squash", "rebase"].include?(thumb_config['merge_method']) ? thumb_config['merge_method'] :  "squash"
         merge_options = { merge_method:  merge_method, accept: "application/vnd.github.polaris-preview+json" }
         merge_response = client.merge_pull_request(@repo, @pr.number, commit_message, merge_options)
         merge_comment="Successfully merged *#{@repo}/pulls/#{@pr.number}* (*#{most_recent_head_sha}* on to *#{@pr.base.ref}*)\n\n"


### PR DESCRIPTION
This allows you to specify merge_method in the config, to be used on the final merge request.
It also changes the default merge_method to squash, which was 'merge' before.

example with setting:

``` merge_method: squash # default ``` 

 https://github.com/davidx/prtester/pull/313

https://developer.github.com/v3/pulls/#merge-a-pull-request-merge-button
