### PR TITLE
Commit message

### DIFF
--- a/lib/thumbs/pull_request_worker.rb
+++ b/lib/thumbs/pull_request_worker.rb
@@ -413,7 +413,6 @@ module Thumbs
       bot_comments.collect do |c|
         next unless c[:body].lines.length > 1
         status_line = c[:body].lines[2]
-        p status_line
         next unless status_line =~ /^\|\s#{pr.head.ref} #{most_recent_head_sha.slice(0, 7)} \| :arrow_right: \| #{pr.base.ref} #{most_recent_base_sha.slice(0, 7)}/
         c
       end.compact[0] || {:body => ""}

--- a/lib/thumbs/pull_request_worker.rb
+++ b/lib/thumbs/pull_request_worker.rb
@@ -395,7 +395,7 @@ module Thumbs
       status_emoji=(progress_status==:completed ? result_image(aggregate_build_status_result) : result_image(progress_status))
       comment_title="|  |  | |  |\n"
       comment_title<<"| ------------ | -------------|------------ | ------------- |\n"
-      comment_title<<"| #{pr.head.ref} #{most_recent_head_sha.slice(0, 7)} | :arrow_right: | #{pr.base.ref} #{most_recent_base_sha.slice(0, 7)} | #{status_emoji} #{progress_status} |"
+      comment_title<<"#{pr.head.ref} #{most_recent_head_sha.slice(0, 7)} | :arrow_right: | #{pr.base.ref} #{most_recent_base_sha.slice(0, 7)} | #{status_emoji} #{progress_status} |"
       comment_title
     end
 
@@ -413,7 +413,7 @@ module Thumbs
       bot_comments.collect do |c|
         next unless c[:body].lines.length > 1
         status_line = c[:body].lines[2]
-        next unless status_line =~ /^\|\s#{pr.head.ref} #{most_recent_head_sha.slice(0, 7)} \| :arrow_right: \| #{pr.base.ref} #{most_recent_base_sha.slice(0, 7)}/
+        next unless status_line =~ /^#{pr.head.ref} #{most_recent_head_sha.slice(0, 7)} \| :arrow_right: \| #{pr.base.ref} #{most_recent_base_sha.slice(0, 7)}/
         c
       end.compact[0] || {:body => ""}
     end

--- a/lib/thumbs/pull_request_worker.rb
+++ b/lib/thumbs/pull_request_worker.rb
@@ -601,7 +601,12 @@ module Thumbs
 
       begin
         debug_message("Starting github API merge request")
-        commit_message = 'Thumbs Git Robot Merge. '
+        commits = client.pull_request_commits(repo, pr.number)
+        commit_lines= commits.collect do |c|
+          "* #{c[:commit][:message]}"
+        end
+
+        commit_message = commit_lines.join("\n")
         merge_method = thumb_config['merge_method'] && ["merge", "squash", "rebase"].include?(thumb_config['merge_method']) ? thumb_config['merge_method'] :  "squash"
         merge_options = { merge_method:  merge_method, accept: "application/vnd.github.polaris-preview+json" }
         merge_response = client.merge_pull_request(@repo, @pr.number, commit_message, merge_options)

--- a/lib/thumbs/pull_request_worker.rb
+++ b/lib/thumbs/pull_request_worker.rb
@@ -395,7 +395,7 @@ module Thumbs
       status_emoji=(progress_status==:completed ? result_image(aggregate_build_status_result) : result_image(progress_status))
       comment_title="|  |  | |  |\n"
       comment_title<<"| ------------ | -------------|------------ | ------------- |\n"
-      comment_title<<"#{pr.head.ref} #{most_recent_head_sha.slice(0, 7)} | :arrow_right: | #{pr.base.ref} #{most_recent_base_sha.slice(0, 7)} | #{status_emoji} #{progress_status} |"
+      comment_title<<"#{pr.head.ref} #{most_recent_head_sha.slice(0, 7)} | :arrow_right: | #{pr.base.ref} #{most_recent_base_sha.slice(0, 7)} | #{status_emoji} #{progress_status}"
       comment_title
     end
 

--- a/lib/thumbs/pull_request_worker.rb
+++ b/lib/thumbs/pull_request_worker.rb
@@ -21,6 +21,7 @@ module Thumbs
       @build_dir=options[:build_dir] || "/tmp/thumbs/#{build_guid}"
       persisted_build_status = read_build_status
       @build_status = persisted_build_status || {:steps => {}}
+
       @build_steps = []
       prepare_build_dir
       load_thumbs_config
@@ -155,7 +156,7 @@ module Thumbs
 
     def try_run_build_step(name, command)
       status={}
-
+      return nil unless thumb_config
       command = "cd #{@build_dir}; #{command}"
 
       debug_message "running command #{command}"
@@ -392,9 +393,9 @@ module Thumbs
     def compose_build_status_comment_title(progress_status)
       pr = client.pull_request(repo, @pr.number)
       status_emoji=(progress_status==:completed ? result_image(aggregate_build_status_result) : result_image(progress_status))
-      comment_title="|||||\n"
-      comment_title<<"------------ | -------------|------------ | ------------- \n"
-      comment_title<<"#{pr.head.ref} #{most_recent_head_sha.slice(0, 7)} | :arrow_right: | #{pr.base.ref} #{most_recent_base_sha.slice(0, 7)} | #{status_emoji} #{progress_status}"
+      comment_title="|  |  | |  |\n"
+      comment_title<<"| ------------ | -------------|------------ | ------------- |\n"
+      comment_title<<"| #{pr.head.ref} #{most_recent_head_sha.slice(0, 7)} | :arrow_right: | #{pr.base.ref} #{most_recent_base_sha.slice(0, 7)} | #{status_emoji} #{progress_status} |"
       comment_title
     end
 
@@ -407,11 +408,13 @@ module Thumbs
     end
 
     def get_build_progress_comment
+      pr = client.pull_request(repo, @pr.number)
+
       bot_comments.collect do |c|
         next unless c[:body].lines.length > 1
         status_line = c[:body].lines[2]
-        pr = client.pull_request(repo, @pr.number)
-        next unless status_line =~ /^#{pr.head.ref} #{most_recent_head_sha.slice(0, 7)} \| :arrow_right: \| #{pr.base.ref} #{most_recent_base_sha.slice(0, 7)}/
+        p status_line
+        next unless status_line =~ /^\|\s#{pr.head.ref} #{most_recent_head_sha.slice(0, 7)} \| :arrow_right: \| #{pr.base.ref} #{most_recent_base_sha.slice(0, 7)}/
         c
       end.compact[0] || {:body => ""}
     end
@@ -462,6 +465,12 @@ module Thumbs
     def clear_build_progress_comment
       build_progress_comment = get_build_progress_comment
       build_progress_comment ? client.delete_comment(repo, build_progress_comment[:id]) : true
+    end
+
+    def archive_build_progress_comment
+      set_build_progress(:archived)
+      build_progress_comment = get_build_progress_comment
+      build_progress_comment ? build_progress_comment[:body].gsub(/^\|/," |") && client.update_comment(repo, build_progress_comment[:id], build_progress_comment[:body]) : true
     end
 
     def pushes
@@ -885,6 +894,7 @@ module Thumbs
     end
 
     def approvals
+
       if thumb_config.key?('org_mode') && thumb_config['org_mode']
         debug_message "returning org_member_code_approvals"
         return org_member_approvals
@@ -922,7 +932,7 @@ module Thumbs
     end
 
     def remove_build_dir
-      FileUtils.mv(@build_dir, "#{@build_dir}.#{DateTime.now.strftime("%s")}")
+      FileUtils.mv(@build_dir, "#{@build_dir}.#{DateTime.now.strftime("%s")}") if File.exist?(@build_dir)
     end
 
     def parse_thumbot_command(text_body)

--- a/lib/thumbs/pull_request_worker.rb
+++ b/lib/thumbs/pull_request_worker.rb
@@ -466,12 +466,6 @@ module Thumbs
       build_progress_comment ? client.delete_comment(repo, build_progress_comment[:id]) : true
     end
 
-    def archive_build_progress_comment
-      set_build_progress(:archived)
-      build_progress_comment = get_build_progress_comment
-      build_progress_comment ? build_progress_comment[:body].gsub(/^\|/," |") && client.update_comment(repo, build_progress_comment[:id], build_progress_comment[:body]) : true
-    end
-
     def pushes
       events.collect { |e| e if e[:type] == 'PushEvent' }.compact
     end

--- a/test/test_build_steps.rb
+++ b/test/test_build_steps.rb
@@ -138,16 +138,18 @@ unit_tests do
             UNMERGABLEPRW.reset_build_status
             UNMERGABLEPRW.unpersist_build_status
             UNMERGABLEPRW.try_merge
-            UNMERGABLEPRW.run_build_steps
-            assert_equal :error, UNMERGABLEPRW.aggregate_build_status_result, UNMERGABLEPRW.build_status
-            step, status = UNMERGABLEPRW.build_status[:steps].collect { |step_name, status| [step_name, status] if status[:result] != :ok }.compact.shift
-            assert_equal :merge, step
+            cassette(:commits) do
+              UNMERGABLEPRW.run_build_steps
+              assert_equal :error, UNMERGABLEPRW.aggregate_build_status_result, UNMERGABLEPRW.build_status
+              step, status = UNMERGABLEPRW.build_status[:steps].collect { |step_name, status| [step_name, status] if status[:result] != :ok }.compact.shift
+              assert_equal :merge, step
 
-            assert status[:result]==:error
-            assert status[:exit_code]!=0
+              assert status[:result]==:error
+              assert status[:exit_code]!=0
 
-            cassette(:get_new_comments, :record => :new_episodes) do
-              assert_equal false, UNMERGABLEPRW.valid_for_merge?
+              cassette(:get_new_comments, :record => :new_episodes) do
+                assert_equal false, UNMERGABLEPRW.valid_for_merge?
+              end
             end
           end
         end

--- a/test/test_merge.rb
+++ b/test/test_merge.rb
@@ -3,7 +3,6 @@ unit_tests do
   test "Can merge forked branch repo" do
      default_vcr_state do
         prw=Thumbs::PullRequestWorker.new(:repo => 'davidx/prtester', :pr => 323)
-
         status = prw.try_merge
 
         assert status.key?(:result)


### PR DESCRIPTION
This enhances the commit message used when merging a pull request.
Before it would just say "Git robot merge" as it was only intended as a temporary placeholder until something better was determined. 
This pr seeks to emulate the button behavior in which it inserts all commit messages in the merge commit.  