### PR TITLE
Specify OTP version

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,15 @@ ask to enable thumbs for your repo.
   build_steps: # your custom build steps
    - "make"
    - "make test"
-  merge: false  # set to true to enable automerging
-  org_mode: true   # only count code reviews from org members.
-  timeout: 1800 
+   
+   # optional
+  merge: false        # Set to true to enable automerging
+  org_mode: true      # Only count code reviews from org members.
+  timeout: 1800       # Let builds run for 30 minutes
+  delete_branch: true # Delete pr branch after a merge
+  otp: R16B03         # Specify a kerl otp release to use.  
+  # R15B03 R15B R16A_RELEASE_CANDIDATE R16B01 R16B02 R16B03-1 R16B03 R16B 17.0-rc1 17.0-rc2 17.0 17.1 17.3 17.4 17.5 18.0 18.1 18.2 18.2.1 18.3 19.0 19.1
+  
   ```
   
 - Add config and create pr branch:

--- a/lib/thumbs/pull_request_worker.rb
+++ b/lib/thumbs/pull_request_worker.rb
@@ -630,7 +630,7 @@ module Thumbs
         merge_response = client.merge_pull_request(@repo, @pr.number, commit_message, merge_options)
         merge_comment="Successfully merged *#{@repo}/pulls/#{@pr.number}* (*#{most_recent_head_sha}* on to *#{@pr.base.ref}*)\n\n"
         merge_comment << " ```yaml    \n#{merge_response.to_hash.to_yaml}\n ``` \n"
-
+        client.delete_branch(@repo, @pr.head.ref) if thumb_config['delete_branch']
         add_comment merge_comment
         debug_message "Merge OK"
       rescue StandardError => e

--- a/lib/thumbs/pull_request_worker.rb
+++ b/lib/thumbs/pull_request_worker.rb
@@ -130,9 +130,27 @@ module Thumbs
       [output, exit_code]
     end
 
+    def otp_installations
+      output, exit_code = run_command("kerl list installations")
+      installations={}
+      output.lines.each do |line|
+        build_name, path = line.split(/\s+/)
+        installations[build] = path
+      end
+      installations
+    end
+
     def run_command_in_shell(command)
       shell=thumb_config['shell']||'/bin/bash'
-
+      if thumb_config.key?('otp')
+        build_name=thumb_config.key?('otp')
+        unless otp_installations.key?(build_name)
+          output =  "OTP #{thumb_config.key?('otp')} not present."
+          return [output, 2]
+        end
+        path=otp_installations[build_name]
+        command = command.prepend(". #{path}/activate")
+      end
       output, exit_code = nil
 
       Open3.popen2e(ENV, shell) do |stdin, stdout_and_stderr, wait_thr|

--- a/lib/thumbs/pull_request_worker.rb
+++ b/lib/thumbs/pull_request_worker.rb
@@ -145,8 +145,9 @@ module Thumbs
       if thumb_config.key?('otp')
         build_name=thumb_config['otp']
         unless otp_installations.key?(build_name)
-          output =  "Version #{thumb_config.key?('otp')} not present.\n"
-          output << "OTP versions supported: `kerl list releases`"
+          output =  "#{thumb_config['otp']} not installed.\n"
+          output << "OTP Versions installed: #{`kerl list installations`}"
+          output << "OTP Versions available: #{`kerl list releases`}"
           return [output, 2]
         end
         path=otp_installations[build_name]

--- a/lib/thumbs/pull_request_worker.rb
+++ b/lib/thumbs/pull_request_worker.rb
@@ -131,11 +131,11 @@ module Thumbs
     end
 
     def otp_installations
-      output, exit_code = run_command("kerl list installations")
+      output, exit_code = `kerl list installations`
       installations={}
       output.lines.each do |line|
         build_name, path = line.split(/\s+/)
-        installations[build] = path
+        installations[build_name] = path
       end
       installations
     end
@@ -143,13 +143,13 @@ module Thumbs
     def run_command_in_shell(command)
       shell=thumb_config['shell']||'/bin/bash'
       if thumb_config.key?('otp')
-        build_name=thumb_config.key?('otp')
+        build_name=thumb_config['otp']
         unless otp_installations.key?(build_name)
           output =  "OTP #{thumb_config.key?('otp')} not present."
           return [output, 2]
         end
         path=otp_installations[build_name]
-        command = command.prepend(". #{path}/activate")
+        command = command.prepend(". #{path}/activate ")
       end
       output, exit_code = nil
 

--- a/lib/thumbs/pull_request_worker.rb
+++ b/lib/thumbs/pull_request_worker.rb
@@ -149,7 +149,7 @@ module Thumbs
           return [output, 2]
         end
         path=otp_installations[build_name]
-        command = command.prepend(". #{path}/activate ")
+        command = command.prepend(". #{path}/activate; ")
       end
       output, exit_code = nil
 

--- a/lib/thumbs/pull_request_worker.rb
+++ b/lib/thumbs/pull_request_worker.rb
@@ -145,7 +145,8 @@ module Thumbs
       if thumb_config.key?('otp')
         build_name=thumb_config['otp']
         unless otp_installations.key?(build_name)
-          output =  "OTP #{thumb_config.key?('otp')} not present."
+          output =  "Version #{thumb_config.key?('otp')} not present.\n"
+          output << "OTP versions supported: `kerl list releases`"
           return [output, 2]
         end
         path=otp_installations[build_name]

--- a/test/test_common.rb
+++ b/test/test_common.rb
@@ -131,7 +131,7 @@ unit_tests do
 
       client2 = Octokit::Client.new(:netrc => true,
                                     :netrc_file => ".netrc.davidpuddy1")
-      cassette(:pr, :record => :new_episodes, :record => :all) do
+      cassette(:pr, :record => :all) do
 
         comment=client2.add_comment(prw.repo, prw.pr.number, "@thumbot wait", options = {})
         sleep 2


### PR DESCRIPTION
This adds the ability to specify OTP version in the .thumbs.yml
The naming should be along the same scheme as kerl list releases

```
R10B-0 R10B-10 R10B-1a R10B-2 R10B-3 R10B-4 R10B-5 R10B-6 R10B-7 R10B-8 R10B-9 R11B-0 R11B-1 R11B-2 R11B-3 R11B-4 R11B-5 R12B-0 R12B-1 R12B-2 R12B-3 R12B-4 R12B-5 R13A R13B01 R13B02-1 R13B02 R13B03 R13B04 R13B R14A R14B01 R14B02 R14B03 R14B04 R14B R14B_erts-5.8.1.1 R15B01 R15B02 R15B02_with_MSVCR100_installer_fix R15B03-1 R15B03 R15B R16A_RELEASE_CANDIDATE R16B01 R16B02 R16B03-1 R16B03 R16B 17.0-rc1 17.0-rc2 17.0 17.1 17.3 17.4 17.5 18.0 18.1 18.2 18.2.1 18.3 19.0 19.1
```

```
otp: 18.0
```
OTP version installation is currently manual. 
Will fail inside build output if OTP version not installed.

example: https://github.com/davidx/example_repo/pull/10