### PR TITLE
add delete_branch

### DIFF
--- a/lib/thumbs/pull_request_worker.rb
+++ b/lib/thumbs/pull_request_worker.rb
@@ -612,6 +612,7 @@ module Thumbs
         merge_response = client.merge_pull_request(@repo, @pr.number, commit_message, merge_options)
         merge_comment="Successfully merged *#{@repo}/pulls/#{@pr.number}* (*#{most_recent_head_sha}* on to *#{@pr.base.ref}*)\n\n"
         merge_comment << " ```yaml    \n#{merge_response.to_hash.to_yaml}\n ``` \n"
+        client.delete_branch(@repo, @pr.head.ref) if thumb_config['delete_branch']
 
         add_comment merge_comment
         debug_message "Merge OK"


### PR DESCRIPTION
This adds a configuration option to delete the pr branch after a merge. 

Fixes https://github.com/basho-labs/thumbs/issues/70

Example: https://github.com/davidx/example_repo/pull/14 

![alt text](http://i.imgur.com/XUL8XW8.png "delete_branch")


