### PR TITLE
Add otp build steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,21 @@ ask to enable thumbs for your repo.
   build_steps: # your custom build steps
    - "make"
    - "make test"
-  merge: false  # set to true to enable automerging
-  org_mode: true   # only count code reviews from org members.
-  timeout: 1800 
+ 
+   # optional
+ 
+  merge: false        # Set to true to enable automerging
+  org_mode: true      # Only count code reviews from org members.
+  timeout: 1800       # Let builds run for 30 minutes
+  delete_branch: true # Delete pr branch after a merge
+  # Specify a kerl otp release to run each set of build steps in. build_steps_<KERLRELEASE>
+  # R15B03 R15B R16A_RELEASE_CANDIDATE R16B01 R16B02 R16B03-1 R16B03 R16B 17.0-rc1 17.0-rc2 17.0 17.1 17.3 17.4 17.5 18.0 18.1 18.2 18.2.1 18.3 19.0 19.1
+  build_steps_R16B03:
+   - make test
+  build_steps_18:
+   - make test
+  build_steps_19:
+   - make pre_19test9-edgecase
   ```
   
 - Add config and create pr branch:

--- a/test/test_build_steps.rb
+++ b/test/test_build_steps.rb
@@ -323,47 +323,9 @@ unit_tests do
     end
   end
 
-  test "can get interpreter build_steps" do
-    default_vcr_state do
-      PRW.respond_to?(:interpreter_build_steps)
-      build_steps = PRW.interpreter_build_steps
-      interpreter=build_steps.keys.first
-      path = build_steps[interpreter]
-    end
-  end
-  test "can get alternate build_steps" do
-    default_vcr_state do
-    end
-  end
 
-  def interpreter_build_steps
-    thumb_config.select { |k, v| k['build_steps_'] }
-  end
 
-  def run_interpreter_build_steps
-    debug_message "running interpreter specific build_steps"
-    # => {"build_steps_18"=>["env", "uptime"], "build_steps_R16B03"=>["env", "uptime"]}
-    interpreter_build_steps.each do |build_step|
-      configured_otp_version = build_step.gsub(/build_steps_/, '')
-      debug_message "got otp version #{configured_otp_version}"
-      if otp_installations.include?(configured_otp_version)
 
-      else
-
-      end
-
-      #      => {"R16B03"=>"/usr/local/erlang"}
-      otp_installations.each do |installed_otp_version, path|
-        if configured_otp_version == installed_otp_version
-
-        end
-# make generic, so can be used for any version of any lang.
-# #initially only support kerl, then add rvm. it'll check to see if that version script exists and load it."
-# build_steps_2.3: :build_steps_ruby-3.4":
-      end
-    end
-
-  end
 end
 
 

--- a/test/test_common.rb
+++ b/test/test_common.rb
@@ -68,7 +68,7 @@ unit_tests do
       PRW.thumb_config.delete('env')
       PRW.build_steps=['echo $TEST_ENV']
       PRW.run_build_steps
-      status=PRW.build_status[:steps]
+      status=PRW.build_status[:main][:steps]
       assert status.kind_of?(Hash), status.inspect
       assert status[:"echo_$TEST_ENV"][:output] !=~/testvalue/
 
@@ -83,12 +83,12 @@ unit_tests do
       PRW.thumb_config.delete('env')
       PRW.build_steps=['echo $SHELL']
       PRW.run_build_steps
-      status=PRW.build_status[:steps][:"echo_$SHELL"]
+      status=PRW.build_status[:main][:steps][:"echo_$SHELL"]
       assert status[:output] =~ /\/bin\/bash/, status[:output].inspect
       assert status[:output] !=~/zsh/
       PRW.thumb_config['shell'] = "/bin/bash"
       PRW.run_build_steps
-      status=PRW.build_status[:steps][:"echo_$SHELL"]
+      status=PRW.build_status[:main][:steps][:"echo_$SHELL"]
       assert_equal '/bin/bash', status[:output].strip, status[:output]
     end
   end

--- a/test/test_merge.rb
+++ b/test/test_merge.rb
@@ -9,7 +9,7 @@ unit_tests do
         assert status.key?(:message)
 
         assert_equal :ok, status[:result]
-        assert_equal status, prw.build_status[:steps][:merge]
+        assert_equal status, prw.build_status[:main][:steps][:merge]
      end
   end
 end

--- a/test/test_persisted_build_status.rb
+++ b/test/test_persisted_build_status.rb
@@ -19,12 +19,13 @@ unit_tests do
             parsed_file = File.exist?(file) ? YAML.load(IO.read(file)) : nil
             assert parsed_file.keys.sort == status.keys.sort
             assert status.kind_of?(Hash)
-            assert status.key?(:steps)
-            assert status[:steps].key?(:merge)
-            assert status[:steps].key?(:make), status[:steps].inspect
-            assert status[:steps].key?(:make_test), status[:steps].inspect
+            assert status.key?(:main)
+            assert status[:main].key?(:steps), status[:main].inspect
+            assert status[:main][:steps].key?(:merge)
+            assert status[:main][:steps].key?(:make), status[:steps].inspect
+            assert status[:main][:steps].key?(:make_test), status[:steps].inspect
 
-            assert PRW.build_status[:steps].keys.length == [:merge, :make, :make_test].length, PRW.build_status[:steps].keys.inspect
+            assert PRW.build_status[:main][:steps].keys.length == [:merge, :make, :make_test].length, PRW.build_status[:main][:steps].keys.inspect
           end
         end
       end
@@ -39,10 +40,10 @@ unit_tests do
 
             PRW.run_build_steps
             test_content=IO.read(File.join(File.dirname(__FILE__), "/data/test_utf8_build_status.txt"))
-            PRW.build_status[:steps][:make][:output] = test_content
+            PRW.build_status[:main][:steps][:make][:output] = test_content
             PRW.persist_build_status
             status = PRW.read_build_status
-            assert_equal PRW.build_status[:steps][:make], status[:steps][:make]
+            assert_equal PRW.build_status[:main][:steps][:make], status[:main][:steps][:make]
           end
         end
       end
@@ -58,7 +59,7 @@ unit_tests do
             PRW.run_build_steps
             PRW.persist_build_status
             status = PRW.read_build_status
-            assert_equal PRW.build_status[:steps][:make], status[:steps][:make]
+            assert_equal PRW.build_status[:main][:steps][:make], status[:main][:steps][:make]
           end
         end
       end
@@ -82,11 +83,11 @@ unit_tests do
         cassette(:get_events_reload, :record => :new_episodes) do
           PRW.build_steps=["make"]
           PRW.run_build_steps
-          PRW.build_status[:steps][:make][:output]=bad_test_string
+          PRW.build_status[:main][:steps][:make][:output]=bad_test_string
 
           PRW.persist_build_status
 
-          fixed_persisted_bad_test_string = PRW.read_build_status[:steps][:make][:output]
+          fixed_persisted_bad_test_string = PRW.read_build_status[:main][:steps][:make][:output]
           assert_equal "hi �", fixed_persisted_bad_test_string
         end
       end

--- a/test/test_persisted_build_status.rb
+++ b/test/test_persisted_build_status.rb
@@ -8,8 +8,8 @@ unit_tests do
             PRW.reset_build_status
             PRW.unpersist_build_status
             PRW.build_steps=["make", "make test"]
-            PRW.run_build_steps
             PRW.try_merge
+            PRW.run_build_steps
             PRW.persist_build_status
             status = PRW.read_build_status
 
@@ -22,8 +22,9 @@ unit_tests do
             assert status.key?(:main)
             assert status[:main].key?(:steps), status[:main].inspect
             assert status[:main][:steps].key?(:merge)
-            assert status[:main][:steps].key?(:make), status[:steps].inspect
-            assert status[:main][:steps].key?(:make_test), status[:steps].inspect
+            assert status[:main][:steps].key?(:make), status[:main][:steps].inspect
+
+            assert status[:main][:steps].key?(:make_test), status[:main][:steps].inspect
 
             assert PRW.build_status[:main][:steps].keys.length == [:merge, :make, :make_test].length, PRW.build_status[:main][:steps].keys.inspect
           end

--- a/test/test_webhook.rb
+++ b/test/test_webhook.rb
@@ -126,8 +126,8 @@ class WebhookTest < Test::Unit::TestCase
       PRW.unpersist_build_status
       PRW.build_steps=["make", "make test"]
       PRW.try_merge
-      assert PRW.build_status[:steps].keys.length == 1, PRW.build_status[:steps].inspect
-      assert PRW.build_status[:steps].key?(:merge)
+      assert PRW.build_status[:main][:steps].keys.length == 1, PRW.build_status[:main][:steps].inspect
+      assert PRW.build_status[:main][:steps].key?(:merge)
       remove_comments(PRW.repo, PRW.pr.number)
       cassette(:get_comments, :record => :all) do
         cassette(:get_issue_comments, :record => :all) do


### PR DESCRIPTION
This adds the ability to specify an OTP version context for build steps to be run in.
```yaml
build_steps:
 - make
 - make test
build_steps_R16B03:
 - make test
build_steps_18:
 - make test
build_steps_19:
 - make test9-custom-edgecase

```
Example: https://github.com/davidx/example_repo/pull/16 
