### PR TITLE
Add thumbot commands

### DIFF
--- a/lib/thumbs/pull_request_worker.rb
+++ b/lib/thumbs/pull_request_worker.rb
@@ -1041,7 +1041,7 @@ module Thumbs
 
     def parse_thumbot_command(text_body)
       command = parse_thumbot_action(text_body)
-      return nil unless command && [:retry, :merge, :kerl, :rvm, :settings].include?(command)
+      return nil unless command && [:retry, :merge, :kerl, :rvm, :settings, :compact].include?(command)
       command
     end
 
@@ -1051,7 +1051,7 @@ module Thumbs
     end
 
     def run_thumbot_command(command)
-      send("thumbot_#{command}") if [:retry, :merge, :kerl, :rvm, :settings].include?(command)
+      send("thumbot_#{command}") if [:retry, :merge, :kerl, :rvm, :settings, :compact].include?(command)
     end
 
     def thumbot_retry

--- a/lib/thumbs/pull_request_worker.rb
+++ b/lib/thumbs/pull_request_worker.rb
@@ -1036,7 +1036,7 @@ module Thumbs
 
     def parse_thumbot_command(text_body)
       command = parse_thumbot_action(text_body)
-      return nil unless command && [:retry, :merge].include?(command)
+      return nil unless command && [:retry, :merge, :kerl, :rvm, :settings].include?(command)
       command
     end
 
@@ -1046,7 +1046,7 @@ module Thumbs
     end
 
     def run_thumbot_command(command)
-      send("thumbot_#{command}") if [:retry, :merge].include?(command)
+      send("thumbot_#{command}") if [:retry, :merge, :kerl, :rvm, :settings].include?(command)
     end
 
     def thumbot_retry
@@ -1075,6 +1075,30 @@ module Thumbs
       create_reviewers_comment
       add_comment "Merging and closing this pr"
       merge
+      true
+    end
+
+    def thumbot_settings
+      debug_message "received settings command"
+      comment_text =  "```yaml #{@thumb_config.to_yaml}```"
+      add_comment(comment_text)
+      debug_message "finished settings command"
+      true
+    end
+
+    def thumbot_kerl
+      debug_message "received kerl command"
+      comment_text =  "```#{otp_installations}```"
+      add_comment(comment_text)
+      debug_message "finished kerl command"
+      true
+    end
+
+    def thumbot_rvm
+      debug_message "received rvm command"
+      comment_text =  "```#{`rvm list | grep ruby-`}```"
+      add_comment(comment_text)
+      debug_message "finished rvm command"
       true
     end
 

--- a/lib/thumbs/pull_request_worker.rb
+++ b/lib/thumbs/pull_request_worker.rb
@@ -27,7 +27,7 @@ module Thumbs
       load_thumbs_config
       @minimum_reviewers = thumb_config && thumb_config.key?('minimum_reviewers') ? thumb_config['minimum_reviewers'] : 2
       @timeout=thumb_config && thumb_config.key?('timeout') ? thumb_config['timeout'] : 1800
-      @build_steps = thumb_config['build_steps']
+      @build_steps = thumb_config && thumb_config.key?('build_steps') ? thumb_config['build_steps'] : nil
       @interpreter_build_steps = @thumb_config.select { |k, v| k['build_steps_'] }
     end
 

--- a/test/test_common.rb
+++ b/test/test_common.rb
@@ -99,7 +99,18 @@ unit_tests do
       assert prw.all_comments.length > 30
     end
   end
-
+  test "can get only build status comments" do
+    default_vcr_state do
+      PRW.respond_to?(:build_status_comments)
+      prw=Thumbs::PullRequestWorker.new(repo: 'davidx/prtester', pr: 333)
+      build_status_comments=prw.build_status_comments
+      bot_comments=prw.all_bot_comments
+      assert build_status_comments.length != bot_comments.length
+      build_status_comment_ids =  build_status_comments.collect{|c| c[:id] }.compact
+      status_bot_comments =  bot_comments.collect{ |c| c if /\|\s+---/.match(c[:body]) }.compact
+      assert build_status_comment_ids.length == status_bot_comments.length, "#{build_status_comment_ids} #{status_bot_comments}"
+    end
+  end
   test "can determine org_member" do
     default_vcr_state do
       ORGPRW.respond_to?(:org_member?)
@@ -149,7 +160,6 @@ unit_tests do
         end
       end
     end
-
   end
 end
 

--- a/test/test_common.rb
+++ b/test/test_common.rb
@@ -131,7 +131,7 @@ unit_tests do
 
       client2 = Octokit::Client.new(:netrc => true,
                                     :netrc_file => ".netrc.davidpuddy1")
-      cassette(:pr, :record => :new_episodes, :record => :all) do
+      cassette(:pr, :record => :all) do
 
         comment=client2.add_comment(prw.repo, prw.pr.number, "@thumbot wait", options = {})
         sleep 2


### PR DESCRIPTION
This adds some @thumbot commands.
1) @thumbot settings
display current branch settings  
2) @thumbot kerl
(show currently available erlang otp installations)
3) @thumbot rvm
(show currently available rvm installations)
4) @thumbot compact
(remove all but one build status comment)

example: https://github.com/davidx/example_repo/pull/16